### PR TITLE
fix: show default amounts as 1 of each token

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition to funding the faucet address with the new token, update the `contra
 Replace net with proper net
 
 ```
-yarn cli config:set --net alfajores --faucetGoldAmount 5000000000000000000 --faucetStableAmount 10000000000000000000
+yarn cli config:set --net alfajores --faucetGoldAmount 1000000000000000000 --faucetStableAmount 1000000000000000000
 ```
 
 You can verify with `yarn cli config:get --net alfajores`


### PR DESCRIPTION
### Description

updates suggested defaults to 1 of each token


### Tested

n/a
### Related issues

- Fixes https://github.com/celo-org/faucet/issues/2

