### PR TITLE
Cashflow for big faucet safe

### DIFF
--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -104,6 +104,14 @@ yargs
         .option('faucetStableAmount', {
           type: 'string',
         })
+        .option('bigFaucetSafeAmount', {
+          type: 'string',
+          description: "Amount of CELO to be sent to *bigFaucetSafeAddress* each time the script runs"
+        })
+        .option('bigFaucetSafeAddress', {
+          type: 'string',
+          description: "Address for the Celo Safe used for distributing large amounts of CELO to developers by request"
+        })
         .option('expirySeconds', {
           type: 'number',
           description: 'Seconds before the escrow expires',
@@ -116,6 +124,8 @@ yargs
       setConfig(args.net, {
         faucetGoldAmount: args.faucetGoldAmount,
         faucetStableAmount: args.faucetStableAmount,
+        bigFaucetSafeAmount: args.bigFaucetSafeAmount,
+        bigFaucetSafeAddress: args.bigFaucetSafeAddress,
         nodeUrl: args.nodeUrl,
         expirySeconds: args.expirySeconds,
       })
@@ -134,6 +144,8 @@ function setConfig(network: string, config: Partial<NetworkConfig>) {
     setIfPresent('node_url', config.nodeUrl),
     setIfPresent('faucet_gold_amount', config.faucetGoldAmount),
     setIfPresent('faucet_stable_amount', config.faucetStableAmount),
+    setIfPresent('big_faucet_safe_address', config.bigFaucetSafeAddress),
+    setIfPresent('big_faucet_safe_amount', config.bigFaucetSafeAmount),
     setIfPresent('expiry_seconds', config.expirySeconds),
   ].join(' ')
   execSync(`yarn firebase functions:config:set ${variables}`, { stdio: 'inherit' })

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -108,14 +108,15 @@ yargs
           type: 'string',
           description: "Amount of CELO to be sent to *bigFaucetSafeAddress* each time the script runs"
         })
+        .option('bigFaucetSafeStablesAmount', {
+          type: 'string',
+          description: "Amount of Stables to be sent to *bigFaucetSafeAddress* each time the script runs"
+        })
         .option('bigFaucetSafeAddress', {
           type: 'string',
           description: "Address for the Celo Safe used for distributing large amounts of CELO to developers by request"
         })
-        .option('expirySeconds', {
-          type: 'number',
-          description: 'Seconds before the escrow expires',
-        })
+
         .option('deploy', {
           type: 'boolean',
           description: 'Wether to deploy functions after set config',
@@ -125,9 +126,9 @@ yargs
         faucetGoldAmount: args.faucetGoldAmount,
         faucetStableAmount: args.faucetStableAmount,
         bigFaucetSafeAmount: args.bigFaucetSafeAmount,
+        bigFaucetSafeStablesAmount: args.bigFaucetSafeStablesAmount,
         bigFaucetSafeAddress: args.bigFaucetSafeAddress,
         nodeUrl: args.nodeUrl,
-        expirySeconds: args.expirySeconds,
       })
       if (args.deploy) {
         deployFunctions()
@@ -146,7 +147,7 @@ function setConfig(network: string, config: Partial<NetworkConfig>) {
     setIfPresent('faucet_stable_amount', config.faucetStableAmount),
     setIfPresent('big_faucet_safe_address', config.bigFaucetSafeAddress),
     setIfPresent('big_faucet_safe_amount', config.bigFaucetSafeAmount),
-    setIfPresent('expiry_seconds', config.expirySeconds),
+    setIfPresent('big_faucet_safe_stables_amount', config.bigFaucetSafeStablesAmount),
   ].join(' ')
   execSync(`yarn firebase functions:config:set ${variables}`, { stdio: 'inherit' })
 }
@@ -188,7 +189,7 @@ function clearAccounts(network: string) {
 }
 
 function deployFunctions() {
-  execSync(`yarn firebase deploy --only functions:faucetRequestProcessor,functions:bigFaucetDailyDrip`, {
+  execSync(`yarn firebase deploy --only functions:faucetRequestProcessor,functions:bigFaucetFunder`, {
     stdio: 'inherit',
   })
 }

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -188,7 +188,7 @@ function clearAccounts(network: string) {
 }
 
 function deployFunctions() {
-  execSync(`yarn firebase deploy --only functions:faucetRequestProcessor`, {
+  execSync(`yarn firebase deploy --only functions:faucetRequestProcessor,functions:bigFaucetDailyDrip`, {
     stdio: 'inherit',
   })
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,9 @@ export interface NetworkConfig {
   nodeUrl: string
   faucetGoldAmount: string
   faucetStableAmount: string
-  expirySeconds: number
   bigFaucetSafeAddress: string
   bigFaucetSafeAmount: string
+  bigFaucetSafeStablesAmount: string
 }
 
 
@@ -23,8 +23,8 @@ export function getNetworkConfig(net: string): NetworkConfig {
     nodeUrl: config[net].node_url,
     faucetGoldAmount: config[net].faucet_gold_amount,
     faucetStableAmount: config[net].faucet_stable_amount,
-    expirySeconds: Number(config[net].expiry_seconds),
     bigFaucetSafeAddress: config[net].big_faucet_safe_address,
     bigFaucetSafeAmount: config[net].big_faucet_safe_amount,
+    bigFaucetSafeStablesAmount: config[net].big_faucet_safe_stables_amount,
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ export interface NetworkConfig {
   faucetGoldAmount: string
   faucetStableAmount: string
   expirySeconds: number
+  bigFaucetSafeAddress: string
+  bigFaucetSafeAmount: string
 }
 
 
@@ -22,5 +24,7 @@ export function getNetworkConfig(net: string): NetworkConfig {
     faucetGoldAmount: config[net].faucet_gold_amount,
     faucetStableAmount: config[net].faucet_stable_amount,
     expirySeconds: Number(config[net].expiry_seconds),
+    bigFaucetSafeAddress: config[net].big_faucet_safe_address,
+    bigFaucetSafeAmount: config[net].big_faucet_safe_amount,
   }
 }

--- a/src/database-helper.ts
+++ b/src/database-helper.ts
@@ -83,7 +83,7 @@ export async function fundBigFaucet(pool: AccountPool, config: NetworkConfig) {
       const celo = new CeloAdapter({pk: account.pk, nodeUrl: config.nodeUrl})
 
       // convert some of the massive amount of cEUR and cREAL we have to CELO
-      // this amount should be smaller enough so that it probably doesn't cause slippage
+      // this amount should be small enough so that it probably doesn't cause slippage
       const ONE_THOUSAND_IN_WEI ="1000000000000000000000"
       await celo.convertExtraStablesToCelo(ONE_THOUSAND_IN_WEI)
 

--- a/src/database-helper.ts
+++ b/src/database-helper.ts
@@ -82,7 +82,13 @@ export async function fundBigFaucet(pool: AccountPool, config: NetworkConfig) {
     return await pool.doWithAccount(async (account) => {
       const celo = new CeloAdapter({pk: account.pk, nodeUrl: config.nodeUrl})
 
+      // convert some of the massive amount of cEUR and cREAL we have to CELO
+      // this amount should be smaller enough so that it probably doesn't cause slippage
+      const ONE_THOUSAND_IN_WEI ="1000000000000000000000"
+      await celo.convertExtraStablesToCelo(ONE_THOUSAND_IN_WEI)
+
       await retryAsync(sendCelo, 4, [celo, config.bigFaucetSafeAddress, config.bigFaucetSafeAmount], 2500)
+
     })
   } catch (error) {
     console.error("bigFaucet", ExecutionResult.OtherErr, error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const faucetRequestProcessor = functions
     return processRequest(snap, pool, config)
   })
 
-export const bigFaucetDailyDrip = functions.pubsub.schedule('every day 05:00').onRun(async (context) => {
+export const bigFaucetFunder = functions.pubsub.schedule('every sunday 05:00').onRun(async (context) => {
   const network = 'alfajores'
   const config = getNetworkConfig(network)
     const pool = new AccountPool(db, network, {
@@ -37,8 +37,8 @@ export const bigFaucetDailyDrip = functions.pubsub.schedule('every day 05:00').o
       actionTimeoutMS: 120 * SECOND,
     })
 
-    console.log(`Daily big drip running on ${context.resource.name} with ${config.bigFaucetSafeAmount} CELO for ${config.bigFaucetSafeAddress}`)
-    fundBigFaucet(pool, config)
+    console.log(`Big drip running on ${context.resource.name} with ${config.bigFaucetSafeAmount} CELO + ${config.bigFaucetSafeStablesAmount} cStables for ${config.bigFaucetSafeAddress}`)
+    await fundBigFaucet(pool, config)
 })
 
 // From https://firebase.googleblog.com/2019/04/schedule-cloud-functions-firebase-cron.html

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as admin from 'firebase-admin'
 import * as functions from 'firebase-functions'
 import { getNetworkConfig } from './config'
-import { AccountPool, processRequest } from './database-helper'
+import { AccountPool, fundBigFaucet, processRequest } from './database-helper'
 
 const PROCESSOR_RUNTIME_OPTS: functions.RuntimeOptions = {
   // When changing this, check that actionTimeoutMS is less than this number
@@ -27,6 +27,19 @@ export const faucetRequestProcessor = functions
     })
     return processRequest(snap, pool, config)
   })
+
+export const bigFaucetDailyDrip  = functions.pubsub.schedule('every day 05:00').onRun(async (context) => {
+  const network = 'alfajores'
+  const config = getNetworkConfig(network)
+    const pool = new AccountPool(db, network, {
+      retryWaitMS: SECOND * 4,
+      getAccountTimeoutMS: 30 * SECOND,
+      actionTimeoutMS: 120 * SECOND,
+    })
+
+    console.log(`Daily big drip running on ${context.resource.name} with ${config.bigFaucetSafeAmount} CELO for ${config.bigFaucetSafeAddress}`)
+    return fundBigFaucet(pool, config)
+})
 
 // From https://firebase.googleblog.com/2019/04/schedule-cloud-functions-firebase-cron.html
 // export const scheduledFunctionCrontab = functions.pubsub.schedule('5 11 * * *').onRun((context) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const faucetRequestProcessor = functions
     return processRequest(snap, pool, config)
   })
 
-export const bigFaucetDailyDrip  = functions.pubsub.schedule('every day 05:00').onRun(async (context) => {
+export const bigFaucetDailyDrip = functions.pubsub.schedule('every day 05:00').onRun(async (context) => {
   const network = 'alfajores'
   const config = getNetworkConfig(network)
     const pool = new AccountPool(db, network, {
@@ -38,7 +38,7 @@ export const bigFaucetDailyDrip  = functions.pubsub.schedule('every day 05:00').
     })
 
     console.log(`Daily big drip running on ${context.resource.name} with ${config.bigFaucetSafeAmount} CELO for ${config.bigFaucetSafeAddress}`)
-    return fundBigFaucet(pool, config)
+    fundBigFaucet(pool, config)
 })
 
 // From https://firebase.googleblog.com/2019/04/schedule-cloud-functions-firebase-cron.html


### PR DESCRIPTION
### Description

Sends specified amount of CELO to an address daily. 

### Other changes

Since the faucet currently has a lot of cEUR + cREAL (far to many to convert at once without slippage) this will convert 1000 of them daily until there are only 25,000 left. 

### Tested

ran locally

### Related issues

- Fixes #18

