### PR TITLE
Phase down fauceted amount for when recipient already has a lot of coin

### DIFF
--- a/apps/firebase/database-rules.bolt
+++ b/apps/firebase/database-rules.bolt
@@ -6,9 +6,10 @@ type Request {
   mobileOS: String | Null,
   dollarTxHash: String | Null,    // Transaction Hash for the executed Request
   goldTxHash: String | Null,
-  escrowTxHash: String | Null,     
+  escrowTxHash: String | Null,
   status: RequestStatus,          // Request Status enum
   type: RequestType,               // Request Type enum
+  tokens: RequestedTokenSet,
 }
 
 type Account {
@@ -22,11 +23,19 @@ type Account {
  */
 
 type RequestStatus extends String {
-  validate() { 
+  validate() {
     this == 'Pending' ||
     this == 'Working' ||
     this == 'Done'    ||
     this == 'Failed'
+  }
+}
+
+type RequestedTokenSet extends String {
+  validate() {
+    this === 'All' ||
+    this === 'Stables' ||
+    this === 'Celo'
   }
 }
 

--- a/apps/firebase/package.json
+++ b/apps/firebase/package.json
@@ -12,7 +12,7 @@
     "deploy:prod": "firebase deploy --project celo-faucet",
     "clean": "tsc -b . --clean",
     "build": "tsc -b .",
-    "lint": "eslint -c ./.eslintrc.js --ext .ts ./src",
+    "lint": "eslint -c ../../.eslintrc.js --ext .ts ./src",
     "transfer-funds": "ts-node scripts/transfer-funds.ts",
     "cli": "ts-node scripts/cli.ts",
     "build:rules": "firebase-bolt database-rules.bolt",

--- a/apps/firebase/src/database-helper.ts
+++ b/apps/firebase/src/database-helper.ts
@@ -125,7 +125,7 @@ async function sendGold(celo: CeloAdapter, address: Address, amount: string, sna
   console.info(`req(${snap.key}): Sending ${actualAmount.toString()} celo to ${address} (balance ${recipientBalance.toString()})`)
   if (actualAmount.eq(0)) {
     console.info(`req(${snap.key}): CELO Transaction SKIPPED`)
-    snap.ref.update({goldTxHash: 'skipped'})
+    await snap.ref.update({goldTxHash: 'skipped'})
     return "skipped"
   }
   const goldTxHash = await sendCelo(celo, address, amount)

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -8,11 +8,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FaucetAPIResponse>
 ) {
-  const { captchaToken, beneficiary } = req.body
+  const { captchaToken, beneficiary, skipStables } = req.body
   const captchaResponse = await captchaVerify(captchaToken)
   if (captchaResponse.success) {
     try {
-      const key = await sendRequest(beneficiary)
+      const key = await sendRequest(beneficiary, skipStables)
       res.status(200).json({ status: RequestStatus.Pending, key })
     } catch (error) {
       console.error(error)

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -24,11 +24,6 @@ export default function Home() {
           <header className={styles.center}>
             <h1 className={`${inter.className} ${styles.title}`}>Alfajores Token Faucet</h1>
           </header>
-          <div className={styles.intro}>
-            <p className={`${inter.className} ${styles.center}`}>
-              Enter your testnet address below. Each request gives you: 5 CELO, 5 cUSD, 5 cEUR, & 5 cREAL*.
-            </p>
-          </div>
           <div className={styles.center}>
             <RequestForm />
           </div>

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           <div className={styles.center}>
             <RequestForm />
           </div>
-          <small>*Accounts with large balances will received a phased down amount. Please consider sending back any tokens you don't need.</small>
+          <small>*Accounts with large balances will received a phased down amount. Please consider sending back any tokens you wont need.</small>
         </div>
         <footer className={styles.grid}>
 

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -26,12 +26,13 @@ export default function Home() {
           </header>
           <div className={styles.intro}>
             <p className={`${inter.className} ${styles.center}`}>
-              Enter your testnet address below. Each request gives you: 5 CELO, 5 cUSD, 5 cEUR, & 5 cREAL.
+              Enter your testnet address below. Each request gives you: 5 CELO, 5 cUSD, 5 cEUR, & 5 cREAL*.
             </p>
           </div>
           <div className={styles.center}>
             <RequestForm />
           </div>
+          <small>*Accounts with large balances will received a phased down amount. Please consider sending back any tokens you don't need.</small>
         </div>
         <footer className={styles.grid}>
 

--- a/apps/web/src/faucet-interfaces.ts
+++ b/apps/web/src/faucet-interfaces.ts
@@ -20,6 +20,13 @@ export interface RequestRecord {
   type: RequestType
   dollarTxHash?: string
   goldTxHash?: string
+  tokens?: RequestedTokenSet
+}
+
+export enum RequestedTokenSet {
+  All = 'All',
+  Stables = 'Stables',
+  Celo = 'Celo'
 }
 
 export type FaucetAPIResponse = {

--- a/apps/web/src/faucet-status.tsx
+++ b/apps/web/src/faucet-status.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
-import { inter } from './request-form'
 import { RequestRecord, RequestStatus } from 'src/faucet-interfaces'
 import subscribe from 'src/firebase-client'
 import styles from 'styles/Form.module.css'
+import { inter } from './request-form'
 
 interface StatusProps {
   faucetRequestKey: string | null
@@ -46,10 +46,12 @@ export default function FaucetStatus({reset, faucetRequestKey, isExecuting, erro
     console.error("Faucet Error", errors)
   }
 
-
   return <div className={styles.center}>
     <h3 className={`${inter.className} ${styles.status}`} aria-live='polite'>Status: {errors?.length || failureStatus?.length ? "Error" : faucetRecord?.status ?? "Initializing"}</h3>
     {faucetRecord?.goldTxHash ?
+      faucetRecord.goldTxHash === 'skipped' ? <span className={inter.className}>
+        No celo was transferred as the account already has a large celo balance.
+      </span> :
       <a className={inter.className} target="_blank" rel="noreferrer" href={`https://alfajores.celoscan.io/tx/${faucetRecord.goldTxHash}`}>
         View on CeloScan
       </a>

--- a/apps/web/src/faucet-status.tsx
+++ b/apps/web/src/faucet-status.tsx
@@ -21,7 +21,7 @@ export default function FaucetStatus({reset, faucetRequestKey, isExecuting, erro
       goldTxHash
     })
     if (status === RequestStatus.Done) {
-      setTimeout(reset, 1_000)
+      setTimeout(reset, 2_000)
     }
   }, [reset])
 

--- a/apps/web/src/firebase-serverside.ts
+++ b/apps/web/src/firebase-serverside.ts
@@ -4,6 +4,7 @@ import "firebase/compat/database"
 import {
   Address,
   NETWORK,
+  RequestedTokenSet,
   RequestRecord,
   RequestStatus,
   RequestType
@@ -36,11 +37,13 @@ async function getDB(): Promise<firebase.database.Database> {
 
 export async function sendRequest(
   beneficiary: Address,
+  skipStables: boolean
 ) {
   const newRequest: RequestRecord = {
     beneficiary,
     status: RequestStatus.Pending,
-    type: RequestType.Faucet
+    type: RequestType.Faucet,
+    tokens: skipStables ? RequestedTokenSet.Celo : RequestedTokenSet.Stables
   }
 
   try {

--- a/apps/web/styles/Form.module.css
+++ b/apps/web/styles/Form.module.css
@@ -5,6 +5,13 @@
   align-items: center;
 }
 
+.intro {
+  max-width: 420px;
+  font-size: 1rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
 .label {
   margin: 0.25rem;
   font-family: "Inter", Arial, Helvetica, sans-serif;
@@ -21,6 +28,7 @@
 }
 
 .status {
+  margin-top: 0.67rem;
   margin-bottom: 1rem
 }
 
@@ -35,6 +43,10 @@
     font-size: 0.85rem;
     width: 320px;
     max-width: 90vw;
+  }
+
+  .intro {
+    text-align: center;
   }
 
 }

--- a/apps/web/styles/Home.module.css
+++ b/apps/web/styles/Home.module.css
@@ -74,7 +74,13 @@
     align-self: center;
     justify-content: center;
     max-width: 100%;
+    width: 400px;
   }
+
+.container small {
+  margin-top: 2rem;
+  text-align: center;
+}
 
 .logo {
   position: fixed;

--- a/apps/web/styles/Home.module.css
+++ b/apps/web/styles/Home.module.css
@@ -7,12 +7,7 @@
   min-height: 100vh;
 }
 
-.intro {
-  max-width: 420px;
-  font-size: 1rem;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
+
 
 .grid {
   display: grid;
@@ -136,9 +131,7 @@
     margin-bottom: 0.5rem;
   }
 
-  .intro {
-    text-align: center;
-  }
+
 
   .logo {
     position: static;


### PR DESCRIPTION
### Description

Faucet account is being used faster than expected consistently. This PR prevents accounts from receiving tokens when they already have a significant amount of them with a gradual fade out as follows 

* 50 tokens - cut amount given in half 
* 100 tokens cut amount given in a quarter 
* over 150 tokens in recipient balance: send none of that specific token 

### Other changes

remove some unused code

### Tested


### Related issues


### Backwards compatibility

yep
### Documentation

wrote some great comments