### PR TITLE
Remove Cannoli +

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,15 +34,3 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-
-## Adding chains
-
-### Web
-
-Add the chain config to `config/chains.ts`.
-
-Add chain name, `ChainId`, and `FaucetAddress` to enums in `types/index.ts`.
-
-### Firebase
-
-In the `apps/firebase` project run `yarn cli config:set` with the relevent params.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Adding chains
+
+### Web
+
+Add the chain config to config/chains.ts
+Add chain name and chain id and faucetAddress to enums in types/index.ts
+
+### Firebase
+
+In the apps/firebase project run `yarn cli config:set` with the relevent params

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -39,9 +39,10 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 
 ### Web
 
-Add the chain config to config/chains.ts
-Add chain name and chain id and faucetAddress to enums in types/index.ts
+Add the chain config to `config/chains.ts`.
+
+Add chain name, `ChainId`, and `FaucetAddress` to enums in `types/index.ts`.
 
 ### Firebase
 
-In the apps/firebase project run `yarn cli config:set` with the relevent params
+In the `apps/firebase` project run `yarn cli config:set` with the relevent params.

--- a/apps/web/components/request-form.tsx
+++ b/apps/web/components/request-form.tsx
@@ -148,6 +148,7 @@ export const RequestForm: FC<Props> = ({ isOutOfCELO, network }) => {
           />
           <small className={inter.className}> CELO Only</small>
         </label>
+        {/* @ts-ignore */}
         <FaucetStatus
           network={network}
           reset={reset}

--- a/apps/web/components/setup-button.tsx
+++ b/apps/web/components/setup-button.tsx
@@ -1,10 +1,11 @@
-import { FC } from 'react'
 import detectEthereumProvider from '@metamask/detect-provider'
-import { useAsyncCallback } from 'react-use-async-callback'
 import Image from 'next/image'
-import { inter } from 'utils/inter'
+import { FC } from 'react'
+import { useAsyncCallback } from 'react-use-async-callback'
+import { CHAIN_PARAMS } from '../config/chains'
 import styles from 'styles/Home.module.css'
-import { Network, ChainId } from 'types'
+import { ChainId, Network } from 'types'
+import { inter } from 'utils/inter'
 
 interface Props {
   network: Network
@@ -84,20 +85,6 @@ const tokens = {
       address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
     },
   ],
-  cannoli: [
-    {
-      symbol: 'cEUR',
-      address: '0x6ede0baedEb76CdF45B40f79bb466759B9EfF1a0',
-    },
-    {
-      symbol: 'cREAL',
-      address: '0xAa6ba7cFB47C2FC36Cc842eEf67889519ebEF9a7',
-    },
-    {
-      symbol: 'cUSD',
-      address: '0x2Bece2F1e31237085A0da4BB12F091D38d832431',
-    },
-  ],
 }
 
 interface TokenParams {
@@ -142,23 +129,4 @@ interface EthProvider {
     listener: (...args: any[]) => void
   ): this
   removeAllListeners(event?: string | symbol): this
-}
-
-const CHAIN_PARAMS = {
-  alfajores: {
-    chainId: '0xaef3',
-    chainName: 'Alfajores Testnet',
-    nativeCurrency: { name: 'Alfajores Celo', symbol: 'A-CELO', decimals: 18 },
-    rpcUrls: ['https://alfajores-forno.celo-testnet.org'],
-    blockExplorerUrls: ['https://explorer.celo.org/alfajores'],
-    iconUrls: ['future'],
-  },
-  cannoli: {
-    chainId: '0x43ab',
-    chainName: 'Cannoli Testnet',
-    nativeCurrency: { name: 'Cannoli Celo', symbol: 'C-CELO', decimals: 18 },
-    rpcUrls: ['https://forno.cannoli.celo-testnet.org'],
-    blockExplorerUrls: ['https://explorer.celo.org/cannoli'],
-    iconUrls: ['future'],
-  },
 }

--- a/apps/web/components/setup-button.tsx
+++ b/apps/web/components/setup-button.tsx
@@ -2,7 +2,7 @@ import detectEthereumProvider from '@metamask/detect-provider'
 import Image from 'next/image'
 import { FC } from 'react'
 import { useAsyncCallback } from 'react-use-async-callback'
-import { CHAIN_PARAMS } from '../config/chains'
+import { CHAIN_PARAMS, tokens } from '../config/chains'
 import styles from 'styles/Home.module.css'
 import { ChainId, Network } from 'types'
 import { inter } from 'utils/inter'
@@ -68,23 +68,6 @@ export const SetupButton: FC<Props> = ({ network }) => {
 
 function delay(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time))
-}
-
-const tokens = {
-  alfajores: [
-    {
-      symbol: 'cEUR',
-      address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-    },
-    {
-      symbol: 'cREAL',
-      address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-    },
-    {
-      symbol: 'cUSD',
-      address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-    },
-  ],
 }
 
 interface TokenParams {

--- a/apps/web/config/chains.ts
+++ b/apps/web/config/chains.ts
@@ -1,4 +1,19 @@
-export const CHAIN_PARAMS = {
+import { Network } from 'types'
+
+interface ChainParams {
+  chainId: `0x${string}`
+  chainName: string
+  nativeCurrency: {
+    name: string
+    symbol: string
+    decimals: number
+  }
+  rpcUrls: string[]
+  blockExplorerUrls: string[]
+  iconUrls: string[]
+}
+
+export const CHAIN_PARAMS: Record<Network, ChainParams> = {
   alfajores: {
     chainId: '0xaef3',
     chainName: 'Alfajores Testnet',
@@ -7,4 +22,26 @@ export const CHAIN_PARAMS = {
     blockExplorerUrls: ['https://explorer.celo.org/alfajores'],
     iconUrls: ['future'],
   },
+}
+
+interface Token {
+  symbol: string
+  address: `0x${string}`
+}
+
+export const tokens: Record<Network, Token[]> = {
+  alfajores: [
+    {
+      symbol: 'cEUR',
+      address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+    },
+    {
+      symbol: 'cREAL',
+      address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
+    },
+    {
+      symbol: 'cUSD',
+      address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
+    },
+  ],
 }

--- a/apps/web/config/chains.ts
+++ b/apps/web/config/chains.ts
@@ -1,0 +1,10 @@
+export const CHAIN_PARAMS = {
+  alfajores: {
+    chainId: '0xaef3',
+    chainName: 'Alfajores Testnet',
+    nativeCurrency: { name: 'Alfajores Celo', symbol: 'A-CELO', decimals: 18 },
+    rpcUrls: ['https://alfajores-forno.celo-testnet.org'],
+    blockExplorerUrls: ['https://explorer.celo.org/alfajores'],
+    iconUrls: ['future'],
+  },
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "setup": "vercel env pull",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -17,7 +17,8 @@ interface Props {
 const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
   const networkCapitalized = capitalize(network)
 
-  const otherNetwork = network === 'alfajores' ? 'cannoli' : 'alfajores'
+  const otherNetwork =
+    networks.indexOf(network) === 0 ? networks[1] : networks[0]
   return (
     <>
       <Head>
@@ -36,9 +37,11 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
             <h1 className={`${inter.className} ${styles.title}`}>
               {networkCapitalized} Token Faucet
             </h1>
-            <Link className={styles.switchNetwork} href={`/${otherNetwork}`}>
-              Switch to {capitalize(otherNetwork)}
-            </Link>
+            {networks.length > 1 && (
+              <Link className={styles.switchNetwork} href={`/${otherNetwork}`}>
+                Switch to {capitalize(otherNetwork)}
+              </Link>
+            )}
           </header>
           <div className={styles.center}>
             <RequestForm network={network} isOutOfCELO={isOutOfCELO} />

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,17 +1,15 @@
 export type Address = string
 export type E164Number = string
 
-export const networks = ['alfajores', 'cannoli']
-export type Network = 'alfajores' | 'cannoli'
+export const networks = ['alfajores']
+export type Network = 'alfajores'
 
 export enum FaucetAddress {
   alfajores = '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF',
-  cannoli = '0x29954EC661f0c829587ac4527825B7E8C663d0b6',
 }
 
 export enum ChainId {
   alfajores = 44787,
-  cannoli = 17323,
 }
 
 export enum RequestStatus {

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,23 @@
-
 # Welcome to Alfajores Faucet app
 
 This Repo contains the code for the alfajores faucet. This is contained in 2 apps.
 
-* The firebase app contains functions which do the actual fauceting.
+- The firebase app contains functions which do the actual fauceting.
 
-* The web app contains a UI for making requests.
+- The web app contains a UI for making requests.
 
 The web app deploys automatically to vercel.
 
-To setup the web app to run locally set the vercel project to clabs/faucet and the env variables from vercel with `vercel env pull` then  run `yarn dev`
+To setup the web app to run locally set the vercel project to clabs/faucet and the env variables from vercel with `vercel env pull` then run `yarn dev`
 
+## Adding chains
 
+### Web
+
+- Add the chain config and token info to `config/chains.ts`.
+
+- Add chain name to the networks array, and `ChainId` and `FaucetAddress` to enums in `types/index.ts`.
+
+### Firebase
+
+In the `apps/firebase` project run `yarn cli config:set` with the relevant params.


### PR DESCRIPTION
### Description

removed all references to cannoli
abstracted away reference to the other network
added very basic starting point docs for adding a new network 

### Other changes

added in command `yarn setup` to pull the dev env down provided the person is authenticated to vercel

### Tested

Link to cannoli no longer shows 

### Related issues

- Fixes #86 

### Backwards compatibility

not compatible as we are removing a testnet

