### PR TITLE
Add celo-org presets and remove redundant settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,12 +14,12 @@
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.updateImportsOnFileMove.enabled": "always",
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+    "source.organizeImports": "never"
   },
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": false
+      "source.organizeImports": "never"
     }
   },
   "[javascriptreact]": {
@@ -43,4 +43,9 @@
   "javascript.format.enable": false,
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
+  "[javascriptreact][typescript][typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":rebaseStalePrs",
-    ":gitSignOff"
-  ],
+  "extends": ["local>celo-org/.github:renovate-config"],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
@@ -36,12 +32,6 @@
   },
   "patch": {
     "minimumReleaseAge": "4 days"
-  },
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": [
-      "type:security"
-    ]
   },
   "schedule": ["on tuesday and thursday", "every weekend"]
 }


### PR DESCRIPTION
### Description

Make the Renovate config extend the org-wide one and remove duplicated settings.

### Tested

Other repositories already extend the org presets.