### PR TITLE
Fix  calling status on undefined

### DIFF
--- a/apps/web/utils/firebase-client.ts
+++ b/apps/web/utils/firebase-client.ts
@@ -35,6 +35,8 @@ export async function subscribeRequest(
 
     if (record) {
       onChange(record)
+    } else {
+      console.debug(snap.key, 'exists?', snap.exists())
     }
 
     if (

--- a/apps/web/utils/firebase-client.ts
+++ b/apps/web/utils/firebase-client.ts
@@ -38,8 +38,8 @@ export async function subscribeRequest(
     }
 
     if (
-      record.status === RequestStatus.Done ||
-      record.status === RequestStatus.Failed
+      record?.status === RequestStatus.Done ||
+      record?.status === RequestStatus.Failed
     ) {
       ref.off('value', listener)
     }


### PR DESCRIPTION
### Description

dont call `.status` when `record` is undefined.

### Other changes

whe record is not defined log for debugging

### Tested

