### PR TITLE
Remove Stablecoin access and add guide to Mento page

### DIFF
--- a/apps/web/components/request-form.tsx
+++ b/apps/web/components/request-form.tsx
@@ -28,10 +28,6 @@ export const RequestForm: FC<Props> = ({ isOutOfCELO, network }) => {
   const { executeRecaptcha } = useGoogleReCaptcha()
   const [skipStables, setSkipStables] = useState(true)
 
-  const toggleStables = useCallback(() => {
-    setSkipStables(!skipStables)
-  }, [skipStables])
-
   const [faucetRequestKey, setKey] = useState<string | null>(null)
   const [failureStatus, setFailureStatus] = useState<string | null>(null)
 
@@ -137,18 +133,9 @@ export const RequestForm: FC<Props> = ({ isOutOfCELO, network }) => {
           className={styles.button}
           type="submit"
         >
-          {'Faucet'}
+          {'Claim CELO'}
         </button>
-        <label>
-          <input
-            onChange={toggleStables}
-            name="token-request"
-            value={'skip-stables'}
-            type={'checkbox'}
-            defaultChecked={skipStables}
-          />
-          <small className={inter.className}> CELO Only</small>
-        </label>
+
         {/* @ts-ignore */}
         <FaucetStatus
           network={network}

--- a/apps/web/components/setup-button.tsx
+++ b/apps/web/components/setup-button.tsx
@@ -60,7 +60,7 @@ export const SetupButton: FC<Props> = ({ network }) => {
         Add Celo Testnet <span>&gt;</span>
       </h3>
       <p className={inter.className}>
-        Enable {networkCapitalized} and Register Mento tokens in Metamask
+        Enable {networkCapitalized} and Add Mentos Stablecoins to your Wallet
       </p>
     </button>
   )

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -58,6 +58,14 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
             *Accounts with large balances will receive a phased down amount.
             Please consider returning any tokens you won&#39;t need.
           </small>
+          <small className={`${styles.phaseDown} ${inter.className}`}>
+            Swap CELO for cUSD, cEUR, or cREAL on{' '}
+            <u>
+              <Link href="https://app.mento.org/">mento</Link>
+            </u>{' '}
+            . For other tokens like USDT or USDC, swap CELO to cUSD first, then
+            exchange to your desired token.
+          </small>
         </div>
         <footer className={styles.grid}>
           <SetupButton network={network} />

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -19,7 +19,8 @@ export default async function handler(
     console.error('Authentication check failed', e)
   }
 
-  const { captchaToken, beneficiary, skipStables, network } = req.body
+  const { captchaToken, beneficiary, network } = req.body
+  const skipStables = true
 
   if (!networks.includes(network)) {
     res.status(400).json({


### PR DESCRIPTION
### Description

Revamp The UI to StableCoin Access where only celo  test token are given from the faucet, in case of any test stablecoin 
You have to use the mento swap to swap from the Celo token to the desired stablecoin.
Include a brief explanation on how to swap the tokens with an attached mento swap link. 

### Other changes

Change words on the the "add celo token" section to a specific statement that shows the addition of stablecoins offered by mento.

### Tested

All the updated works smoothly without affecting other sections. No functionality were affected 

### Related issues

- Fixes #197 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_