### PR TITLE
auth expiry

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -40,7 +40,10 @@ export const authOptions: AuthOptions = {
     },
   },
   session: {
-    maxAge: 10 * 60, // 10 minutes in seconds
+    maxAge: 2 * 60, // 2 minutes in seconds
+  },
+  jwt: {
+    maxAge: 60 // seconds
   }
 }
 

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -39,6 +39,9 @@ export const authOptions: AuthOptions = {
       return session
     },
   },
+  session: {
+    maxAge: 10 * 60, // 10 minutes in seconds
+  }
 }
 
 export default NextAuth(authOptions)


### PR DESCRIPTION
### Description

by default these sessions last a month which is just way longer than needed. 


set jwt max age for how often those tokens are updated. 

### Other changes


### Tested

ran locally and after expiration time  was logged out.  

### Related issues

