### PR TITLE
fix: use `<a>` instead of `<Link>` for external URL

### DIFF
--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -50,7 +50,7 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
           <small className={`${styles.phaseDown} ${inter.className}`}>
             Need <b>USDC</b>? Get tokens at{' '}
             <u>
-              <Link href="https://faucet.circle.com/">faucet.circle.com</Link>
+              <a href="https://faucet.circle.com/" target="_blank" rel="noopener noreferrer">faucet.circle.com</a>
             </u>
           </small>
 


### PR DESCRIPTION
### Description

noticed that we were using `next/link` for an external URL, which isn't correct per the Next.js docs.
replaced it with a regular `<a>` tag to avoid any routing issues or console warnings.