### PR TITLE
add conditional to be used or deploying to prod or staging

### DIFF
--- a/.github/workflows/deploy-chain.yaml
+++ b/.github/workflows/deploy-chain.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-faucet-master/providers/github-by-repos
-          service_account: faucet-deploy-firebase@celo-faucet.iam.gserviceaccount.com
+          service_account: ${{ PROD == true ? faucet-deploy-firebase@celo-faucet.iam.gserviceaccount.com : faucet-deploy-firebase-staging@celo-faucet-staging.iam.gserviceaccount.com  }}
  
       - name: Set Firebase project and Deploy Firebase Function
         working-directory: apps/firebase


### PR DESCRIPTION
### Description

This is adding a conditional that deploys to a different GCP project based on the PROD boolean variable.  If true, deploy to faucet, if false or empty, deploy to faucet-staging.