### PR TITLE
Remove Celo Alfajores testnet support

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint
 

--- a/apps/firebase/src/celo-adapter.test.ts
+++ b/apps/firebase/src/celo-adapter.test.ts
@@ -1,5 +1,5 @@
 import { parseEther } from 'viem'
-import { celoAlfajores, celoSepolia } from 'viem/chains'
+import { celoSepolia } from 'viem/chains'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CeloAdapter } from './celo-adapter'
 
@@ -9,15 +9,13 @@ describe('CeloAdapter Integration Tests', () => {
     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as const
   // this is NOT the address of the test private key
   const validAddress = '0x744a3f56D61487FA2cD5a09262d31E6222DC136E' as const
-  const testNodeUrls = {
-    alfajores: celoAlfajores.rpcUrls.default.http[0],
-    sepolia: celoSepolia.rpcUrls.default.http[0],
-  }
+  const testNodeUrl = celoSepolia.rpcUrls.default.http[0]
+
   describe('Constructor', () => {
-    it('creates an adapter with Alfajores chain when nodeUrl contains alfajores', () => {
+    it('creates an adapter with Sepolia chain', () => {
       const adapter = new CeloAdapter({
         pk: testPrivateKey,
-        nodeUrl: testNodeUrls.alfajores,
+        nodeUrl: testNodeUrl,
       })
 
       // Verify the adapter was created successfully
@@ -27,17 +25,7 @@ describe('CeloAdapter Integration Tests', () => {
       expect(typeof adapter.transferCelo).toBe('function')
     })
 
-    it('creates an adapter with Sepolia chain when nodeUrl contains sepolia', () => {
-      const adapter = new CeloAdapter({
-        pk: testPrivateKey,
-        nodeUrl: testNodeUrls.sepolia,
-      })
-
-      expect(adapter).toBeInstanceOf(CeloAdapter)
-      expect(typeof adapter.transferCelo).toBe('function')
-    })
-
-    it('defaults to Sepolia chain when nodeUrl does not contain alfajores', () => {
+    it('defaults to Sepolia chain for any nodeUrl', () => {
       const adapter = new CeloAdapter({
         pk: testPrivateKey,
         nodeUrl: 'https://some-other-node.org',
@@ -54,7 +42,7 @@ describe('CeloAdapter Integration Tests', () => {
       vi.resetAllMocks()
       adapter = new CeloAdapter({
         pk: testPrivateKey,
-        nodeUrl: testNodeUrls.alfajores,
+        nodeUrl: testNodeUrl,
       })
       vi.spyOn(adapter.client, 'sendTransaction').mockResolvedValue(
         '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as const,
@@ -78,7 +66,7 @@ describe('CeloAdapter Integration Tests', () => {
       expect(adapter.client.sendTransaction).toHaveBeenCalledWith({
         to: validAddress,
         value: amount,
-        chain: celoAlfajores,
+        chain: celoSepolia,
       })
     })
 
@@ -95,27 +83,17 @@ describe('CeloAdapter Integration Tests', () => {
         expect(adapter.client.sendTransaction).toHaveBeenCalledWith({
           to: validAddress,
           value: amount,
-          chain: celoAlfajores,
+          chain: celoSepolia,
         })
       })
     })
   })
 
   describe('Chain Configuration', () => {
-    it('uses correct chain configuration for Alfajores', () => {
-      const adapter = new CeloAdapter({
-        pk: testPrivateKey,
-        nodeUrl: testNodeUrls.alfajores,
-      })
-
-      // Verify the adapter was created with Alfajores configuration
-      expect(adapter).toBeInstanceOf(CeloAdapter)
-    })
-
     it('uses correct chain configuration for Sepolia', () => {
       const adapter = new CeloAdapter({
         pk: testPrivateKey,
-        nodeUrl: testNodeUrls.sepolia,
+        nodeUrl: testNodeUrl,
       })
 
       // Verify the adapter was created with Sepolia configuration
@@ -129,33 +107,26 @@ describe('CeloAdapter Integration Tests', () => {
       expect(() => {
         new CeloAdapter({
           pk: 'invalid-private-key' as any,
-          nodeUrl: testNodeUrls.alfajores,
+          nodeUrl: testNodeUrl,
         })
       }).toThrow()
     })
   })
 
   describe('Real Network Integration', () => {
-    it('creates adapter instances without throwing network errors', () => {
-      // Test that we can create adapters for both networks
-      const alfajoresAdapter = new CeloAdapter({
+    it('creates adapter instance without throwing network errors', () => {
+      const adapter = new CeloAdapter({
         pk: testPrivateKey,
-        nodeUrl: testNodeUrls.alfajores,
+        nodeUrl: testNodeUrl,
       })
 
-      const sepoliaAdapter = new CeloAdapter({
-        pk: testPrivateKey,
-        nodeUrl: testNodeUrls.sepolia,
-      })
-
-      expect(alfajoresAdapter).toBeInstanceOf(CeloAdapter)
-      expect(sepoliaAdapter).toBeInstanceOf(CeloAdapter)
+      expect(adapter).toBeInstanceOf(CeloAdapter)
     })
 
     it('handles method calls without network errors', async () => {
       const adapter = new CeloAdapter({
         pk: testPrivateKey,
-        nodeUrl: testNodeUrls.alfajores,
+        nodeUrl: testNodeUrl,
       })
 
       // The method should be callable (though it will fail due to insufficient funds)

--- a/apps/firebase/src/celo-adapter.ts
+++ b/apps/firebase/src/celo-adapter.ts
@@ -9,19 +9,19 @@ import {
   WalletClient,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { celoAlfajores, celoSepolia } from 'viem/chains'
+import { celoSepolia } from 'viem/chains'
 
 export class CeloAdapter {
   public readonly client: WalletClient<
     Transport,
-    typeof celoAlfajores | typeof celoSepolia,
+    typeof celoSepolia,
     Account
   >
-  private readonly chain: typeof celoAlfajores | typeof celoSepolia
+  private readonly chain: typeof celoSepolia
 
   constructor({ pk, nodeUrl }: { pk: Hex; nodeUrl: string }) {
     const account = privateKeyToAccount(ensureLeading0x(pk))
-    this.chain = nodeUrl.includes('alfajores') ? celoAlfajores : celoSepolia
+    this.chain = celoSepolia
     this.client = createWalletClient({
       account,
       transport: http(nodeUrl),

--- a/apps/firebase/src/config.ts
+++ b/apps/firebase/src/config.ts
@@ -8,12 +8,6 @@ export interface NetworkConfig {
   authenticatedGoldAmount: bigint
 }
 
-const ALFAJORES_CONFIG: NetworkConfig = {
-  nodeUrl: 'https://alfajores-forno.celo-testnet.org',
-  faucetGoldAmount: 300_000_000_000_000_000n,
-  authenticatedGoldAmount: 3_000_000_000_000_000_000n,
-}
-
 const CELO_SEPOLIA_CONFIG: NetworkConfig = {
   nodeUrl: 'https://forno.celo-sepolia.celo-testnet.org',
   faucetGoldAmount: 300_000_000_000_000_000n,
@@ -21,7 +15,6 @@ const CELO_SEPOLIA_CONFIG: NetworkConfig = {
 }
 
 const CONFIGS: Record<string, NetworkConfig> = {
-  alfajores: ALFAJORES_CONFIG,
   'celo-sepolia': CELO_SEPOLIA_CONFIG,
 }
 

--- a/apps/web/components/faucet-header.tsx
+++ b/apps/web/components/faucet-header.tsx
@@ -15,19 +15,6 @@ export const FaucetHeader: FC<Props> = ({ network, isOutOfCELO }) => (
     {isOutOfCELO && (
       <header className={styles.notice}>
         <span>The Faucet is out of CELO for now.</span>
-        {network === 'alfajores' && (
-          <>
-            {' '}
-            It will be topped up{' '}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href="https://explorer.celo.org/alfajores/epochs"
-            >
-              within an hour
-            </a>
-          </>
-        )}
       </header>
     )}
     <div className={`${styles.topBar}`}>

--- a/apps/web/components/mode-toggle.tsx
+++ b/apps/web/components/mode-toggle.tsx
@@ -1,8 +1,8 @@
 import { Moon, Sun } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
 import { useTheme } from 'next-themes'
 import { useCallback } from 'react'
+import { Button } from '@/components/ui/button'
 
 export function ModeToggle() {
   const { theme, setTheme } = useTheme()

--- a/apps/web/config/chains.ts
+++ b/apps/web/config/chains.ts
@@ -1,5 +1,5 @@
 import { Network } from 'types'
-import { celoAlfajores, celoSepolia } from 'viem/chains'
+import { celoSepolia } from 'viem/chains'
 
 interface ChainParams {
   chainId: `0x${string}`
@@ -15,7 +15,6 @@ interface ChainParams {
 }
 
 export const CHAIN_PARAMS: Record<Network, ChainParams> = [
-  { ...celoAlfajores, network: 'alfajores' as Network },
   { ...celoSepolia, network: 'celo-sepolia' as Network },
 ].reduce(
   (acc, chain) => {
@@ -42,19 +41,5 @@ interface Token {
 }
 
 export const tokens: Record<Network, Token[]> = {
-  alfajores: [
-    {
-      symbol: 'cEUR',
-      address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-    },
-    {
-      symbol: 'cREAL',
-      address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
-    },
-    {
-      symbol: 'cUSD',
-      address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-    },
-  ],
   'celo-sepolia': [],
 }

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -4,7 +4,6 @@ import Head from 'next/head'
 import Link from 'next/link'
 import {
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -28,8 +27,6 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
   const networkCapitalized = capitalize(network)
   const { data: session } = useSession()
 
-  const otherNetwork =
-    networks.indexOf(network) === 0 ? networks[1] : networks[0]
   return (
     <>
       <Head>
@@ -46,16 +43,6 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
         <Card className="w-full max-w-sm items-stretch">
           <CardHeader>
             <CardTitle>{networkCapitalized} Token Faucet</CardTitle>
-            <CardDescription>
-              {networks.length > 1 && (
-                <Link
-                  className={styles.switchNetwork}
-                  href={`/${otherNetwork}`}
-                >
-                  Switch to {capitalize(otherNetwork)}
-                </Link>
-              )}
-            </CardDescription>
           </CardHeader>
           <CardContent>
             <RequestForm network={network} isOutOfCELO={isOutOfCELO} />
@@ -79,7 +66,7 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
                 </Link>
               </small>
               <small className={inter.className}>
-                &bull;  {' '}
+                &bull;{' '}
                 <Link className="underline" href="https://app.mento.org/">
                   Swap CELO for Mento Tokens
                 </Link>

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,16 +1,14 @@
 export type Address = string
 export type E164Number = string
 
-export const networks = ['alfajores', 'celo-sepolia'] as const
+export const networks = ['celo-sepolia'] as const
 export type Network = (typeof networks)[number]
 
 export enum FaucetAddress {
-  alfajores = '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF',
   'celo-sepolia' = '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF',
 }
 
 export enum ChainId {
-  alfajores = 44787,
   'celo-sepolia' = 11142220,
 }
 


### PR DESCRIPTION
### Description

This PR removes all support for the Celo Alfajores testnet across the codebase, consolidating on Celo Sepolia as the sole supported testnet. The changes include:

- Removing `celoAlfajores` chain imports and references from adapter and configuration files
- Updating the `CeloAdapter` to always use `celoSepolia` regardless of the provided node URL
- Removing Alfajores-specific configuration, tokens, and network definitions
- Simplifying test cases to focus only on Sepolia chain behavior
- Removing Alfajores-specific UI messaging in the faucet header

The application now exclusively targets the Celo Sepolia testnet for all operations.

### Other changes

- Simplified test setup by removing dual-network test configurations
- Removed Alfajores token definitions (cEUR, cREAL, cUSD) from the token registry
- Cleaned up network type definitions to only include 'celo-sepolia'

### Tested

Existing unit tests have been updated to reflect the single-network configuration. All test cases pass with the new Sepolia-only setup. The adapter initialization, transaction handling, and chain configuration tests all verify correct behavior with the Sepolia chain.

### Related issues

_N/A_

### Backwards compatibility

**Not backwards compatible.** This is a breaking change for any integrations or deployments that rely on Alfajores testnet support. Applications must migrate to use Celo Sepolia instead.

### Documentation

No community-facing documentation changes required. This is an internal infrastructure change consolidating testnet support.

https://claude.ai/code/session_01DgN5oFXec78STFz4cuMmyW