### PR TITLE
Fix RPC timeouts with fallback transports

### DIFF
--- a/apps/web/utils/firebase.serverside.ts
+++ b/apps/web/utils/firebase.serverside.ts
@@ -12,7 +12,7 @@ import {
   RequestStatus,
   RequestType,
 } from 'types'
-import { createPublicClient, getAddress, http } from 'viem'
+import { createPublicClient, fallback, getAddress, http } from 'viem'
 import { celo, mainnet } from 'viem/chains'
 import { config } from './firebase-config'
 
@@ -164,11 +164,18 @@ export async function sendRequest(
 }
 
 const ethPublicClient = createPublicClient({
-  transport: http(),
+  transport: fallback([
+    ...(process.env.ETH_RPC_URL ? [http(process.env.ETH_RPC_URL)] : []),
+    http('https://1rpc.io/eth'),
+    http('https://eth.drpc.org'),
+  ]),
   chain: mainnet,
 })
 const celoPublicClient = createPublicClient({
-  transport: http(),
+  transport: fallback([
+    ...(process.env.CELO_RPC_URL ? [http(process.env.CELO_RPC_URL)] : []),
+    http('https://forno.celo.org'),
+  ]),
   chain: celo,
 })
 const LOCKED_CELO_CONTRACT_ADDRESS =


### PR DESCRIPTION
## Summary
- Replace bare `http()` transports (which fall back to viem's unreliable default public RPCs) with `fallback()` transports using explicit, reliable endpoints
- Ethereum mainnet: `https://1rpc.io/eth` → `https://eth.drpc.org` (in priority order)
- Celo: `https://forno.celo.org`
- Both clients accept an optional env var override (`ETH_RPC_URL`, `CELO_RPC_URL`) that takes highest priority — change endpoints without a code change

## Context
The `/api/faucet` endpoint was timing out on the `addressCanBeElevatedToTrusted` check because viem's default Ethereum RPC (`eth.merkl.io`) is rate-limited and frequently unresponsive.

## Test plan
- [ ] Deploy to preview, call `/api/faucet` and confirm no more timeout errors on mainnet balance check
- [ ] Optionally set `ETH_RPC_URL` env var in Vercel to confirm override takes priority