### PR TITLE
Replace Firebase email/password auth with Admin SDK + GCP Workload Identity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@celo/abis": "^13.0.0",
-    "@firebase/app-types": "^0.9.3",
     "@metamask/detect-provider": "^2.0.0",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
@@ -20,6 +19,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "firebase": "^12.1.0",
+    "firebase-admin": "^13.4.0",
     "lucide-react": "^0.542.0",
     "next": "15.5.9",
     "next-auth": "^4.24.11",

--- a/apps/web/utils/firebase.serverside.ts
+++ b/apps/web/utils/firebase.serverside.ts
@@ -1,8 +1,7 @@
 import { lockedGoldABI } from '@celo/abis'
 import { Redis } from '@upstash/redis'
-import firebase from 'firebase/compat/app'
-import 'firebase/compat/auth'
-import 'firebase/compat/database'
+import { getApps, initializeApp } from 'firebase-admin/app'
+import { getDatabase } from 'firebase-admin/database'
 import {
   Address,
   AuthLevel,
@@ -14,36 +13,16 @@ import {
 } from 'types'
 import { createPublicClient, getAddress, http } from 'viem'
 import { celo, mainnet } from 'viem/chains'
-import { config } from './firebase-config'
+import { getFirebaseCredential } from './gcp-credential'
 
-async function getFirebase() {
-  if (!firebase.apps.length) {
-    firebase.initializeApp(config)
-    const loginUsername = process.env.FIREBASE_LOGIN_USERNAME
-    const loginPassword = process.env.FIREBASE_LOGIN_PASSWORD
-    if (
-      loginUsername === undefined ||
-      loginUsername === null ||
-      loginUsername.length === 0 ||
-      loginPassword === undefined
-    ) {
-      throw new Error('Login username or password is empty')
-    }
-    try {
-      // Source: https://firebase.google.com/docs/auth
-      await firebase
-        .auth()
-        .signInWithEmailAndPassword(loginUsername, loginPassword)
-    } catch (e) {
-      console.error(`Fail to login into Firebase: ${e}`)
-      throw e
-    }
+function getDB() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: getFirebaseCredential(),
+      databaseURL: `https://${process.env.NEXT_PUBLIC_FIREBASE_PID}.firebaseio.com`,
+    })
   }
-  return firebase
-}
-
-async function getDB(): Promise<firebase.database.Database> {
-  return (await getFirebase()).database()
+  return getDatabase()
 }
 
 type RateLimit = Readonly<{ count: number; timePeriodInSeconds: number }>
@@ -91,7 +70,7 @@ export async function sendRequest(
     if (await addressCanBeElevatedToTrusted(beneficiary)) {
       authLevel = AuthLevel.authenticated
     }
-    const db = await getDB()
+    const db = getDB()
     const redis = Redis.fromEnv()
     const namespace = 'rate-limits'
     const ipNamespace = 'ip-counts'
@@ -124,9 +103,7 @@ export async function sendRequest(
       return { reason: 'rate_limited' }
     }
 
-    const ref: firebase.database.Reference = await db
-      .ref(`${network}/requests`)
-      .push(newRequest)
+    const ref = await db.ref(`${network}/requests`).push(newRequest)
 
     const params = {
       // INCREASE GLOBAL COUNT

--- a/apps/web/utils/gcp-credential.ts
+++ b/apps/web/utils/gcp-credential.ts
@@ -1,0 +1,107 @@
+/**
+ * Custom Firebase Admin credential that authenticates via
+ * Vercel OIDC → GCP Workload Identity Federation → Service Account impersonation.
+ *
+ * Env vars required on Vercel:
+ *   GCP_WIF_PROVIDER  – full WIF provider resource name
+ *                       (e.g. //iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider)
+ *   GCP_SERVICE_ACCOUNT – service account email to impersonate
+ *                         (e.g. faucet-web@celo-faucet.iam.gserviceaccount.com)
+ *
+ * Falls back to Application Default Credentials for local development
+ * (run `gcloud auth application-default login` locally).
+ */
+
+import { applicationDefault, Credential } from 'firebase-admin/app'
+
+class VercelWorkloadIdentityCredential implements Credential {
+  private audience: string
+  private serviceAccount: string
+
+  constructor(audience: string, serviceAccount: string) {
+    this.audience = audience
+    this.serviceAccount = serviceAccount
+  }
+
+  async getAccessToken(): Promise<{
+    access_token: string
+    expires_in: number
+  }> {
+    const oidcToken = process.env.VERCEL_OIDC_TOKEN
+    if (!oidcToken) {
+      throw new Error(
+        'VERCEL_OIDC_TOKEN not available — is this running on Vercel?',
+      )
+    }
+
+    // Step 1: Exchange Vercel OIDC token for a GCP federated token via STS
+    const stsRes = await fetch('https://sts.googleapis.com/v1/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        audience: this.audience,
+        scope: 'https://www.googleapis.com/auth/cloud-platform',
+        requested_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        subject_token: oidcToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+      }),
+    })
+
+    if (!stsRes.ok) {
+      const body = await stsRes.text()
+      throw new Error(
+        `GCP STS token exchange failed (${stsRes.status}): ${body}`,
+      )
+    }
+
+    const { access_token: federatedToken } = await stsRes.json()
+
+    // Step 2: Impersonate the target service account
+    const impersonateRes = await fetch(
+      `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${this.serviceAccount}:generateAccessToken`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${federatedToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          scope: [
+            'https://www.googleapis.com/auth/firebase.database',
+            'https://www.googleapis.com/auth/userinfo.email',
+          ],
+          lifetime: '3600s',
+        }),
+      },
+    )
+
+    if (!impersonateRes.ok) {
+      const body = await impersonateRes.text()
+      throw new Error(
+        `GCP service account impersonation failed (${impersonateRes.status}): ${body}`,
+      )
+    }
+
+    const { accessToken, expireTime } = await impersonateRes.json()
+
+    return {
+      access_token: accessToken,
+      expires_in: Math.floor(
+        (new Date(expireTime).getTime() - Date.now()) / 1000,
+      ),
+    }
+  }
+}
+
+export function getFirebaseCredential(): Credential {
+  const wifProvider = process.env.GCP_WIF_PROVIDER
+  const serviceAccount = process.env.GCP_SERVICE_ACCOUNT
+
+  if (wifProvider && serviceAccount) {
+    return new VercelWorkloadIdentityCredential(wifProvider, serviceAccount)
+  }
+
+  // Local development: uses gcloud CLI credentials or GOOGLE_APPLICATION_CREDENTIALS
+  return applicationDefault()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,7 +1164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/app-types@npm:0.9.3, @firebase/app-types@npm:^0.9.3":
+"@firebase/app-types@npm:0.9.3":
   version: 0.9.3
   resolution: "@firebase/app-types@npm:0.9.3"
   checksum: 10c0/02ec9a26c10b9bbb2a1e5b9ae0552b5325b40066e3c23be089ceae53414a1505f2ab716ae1098652a0a0c9992ba322c05371a9b2a837cccfae309788372a72e0
@@ -15296,7 +15296,6 @@ __metadata:
   resolution: "web@workspace:apps/web"
   dependencies:
     "@celo/abis": "npm:^13.0.0"
-    "@firebase/app-types": "npm:^0.9.3"
     "@metamask/detect-provider": "npm:^2.0.0"
     "@radix-ui/react-label": "npm:^2.1.7"
     "@radix-ui/react-slot": "npm:^1.2.3"
@@ -15312,6 +15311,7 @@ __metadata:
     eslint: "npm:8.57.0"
     eslint-config-next: "npm:13.5.6"
     firebase: "npm:^12.1.0"
+    firebase-admin: "npm:^13.4.0"
     lucide-react: "npm:^0.542.0"
     next: "npm:15.5.9"
     next-auth: "npm:^4.24.11"


### PR DESCRIPTION
## Summary
- Switch server-side Firebase from **client SDK with email/password auth** to **Admin SDK with GCP Workload Identity Federation**
- Eliminates long-lived credentials (`FIREBASE_LOGIN_USERNAME` / `FIREBASE_LOGIN_PASSWORD`) from Vercel
- On Vercel: uses the auto-injected OIDC token → GCP STS exchange → service account impersonation (zero stored secrets)
- Locally: falls back to Application Default Credentials (`gcloud auth application-default login`)

## What changed

| File | Change |
|------|--------|
| `apps/web/utils/gcp-credential.ts` | **New** — custom `Credential` implementation: Vercel OIDC → GCP WIF → SA impersonation |
| `apps/web/utils/firebase.serverside.ts` | Replace `firebase/compat` client SDK + email/password auth with `firebase-admin/app` + `firebase-admin/database` |
| `apps/web/package.json` | Add `firebase-admin`, remove `@firebase/app-types` |

## GCP setup required (one-time)

Before deploying, create the Workload Identity Pool + Provider in GCP:

```bash
# 1. Create pool
gcloud iam workload-identity-pools create vercel-faucet \
  --location=global \
  --project=celo-faucet \
  --display-name="Vercel Faucet Deployments"

# 2. Create OIDC provider
gcloud iam workload-identity-pools providers create-oidc vercel-oidc \
  --location=global \
  --workload-identity-pool=vercel-faucet \
  --project=celo-faucet \
  --issuer-uri="https://oidc.vercel.com" \
  --allowed-audiences="https://vercel.com/<your-team>" \
  --attribute-mapping="google.subject=assertion.sub"

# 3. Create a service account (or reuse existing)
gcloud iam service-accounts create faucet-vercel \
  --project=celo-faucet \
  --display-name="Faucet Vercel Web"

# 4. Grant Firebase RTDB access to the SA
gcloud projects add-iam-policy-binding celo-faucet \
  --member="serviceAccount:faucet-vercel@celo-faucet.iam.gserviceaccount.com" \
  --role="roles/firebasedatabase.admin"

# 5. Allow the federated identity to impersonate the SA
gcloud iam service-accounts add-iam-policy-binding \
  faucet-vercel@celo-faucet.iam.gserviceaccount.com \
  --project=celo-faucet \
  --role=roles/iam.workloadIdentityUser \
  --member="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/vercel-faucet/*"
```

## Vercel env vars

**Add:**
| Variable | Value | Example |
|----------|-------|---------|
| `GCP_WIF_PROVIDER` | Full WIF provider resource name | `//iam.googleapis.com/projects/1094498259535/locations/global/workloadIdentityPools/vercel-faucet/providers/vercel-oidc` |
| `GCP_SERVICE_ACCOUNT` | SA email | `faucet-vercel@celo-faucet.iam.gserviceaccount.com` |

**Remove (after deployment verified):**
- `FIREBASE_LOGIN_USERNAME`
- `FIREBASE_LOGIN_PASSWORD`

## Test plan
- [ ] Run GCP setup commands above
- [ ] Add `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT` env vars in Vercel
- [ ] Deploy to preview — verify `/api/faucet` can write to Firebase RTDB
- [ ] Verify client-side real-time status updates still work (uses separate client SDK, unchanged)
- [ ] Remove old `FIREBASE_LOGIN_USERNAME` / `FIREBASE_LOGIN_PASSWORD` from Vercel