### PR TITLE
feat(faucet): add self-serve API-key auth so agents can skip the captcha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Run Tests
         run: yarn --cwd=apps/firebase run test:ci
 
+      - name: Run Web Tests
+        run: yarn --cwd=apps/web run test:ci
+
   validate-renovate-config:
     name: Validate Renovate Config
     runs-on: ubuntu-latest

--- a/apps/firebase/src/celo-adapter.onchain.test.ts
+++ b/apps/firebase/src/celo-adapter.onchain.test.ts
@@ -19,15 +19,22 @@ const enabled = Boolean(
 )
 
 describe.skipIf(!enabled)('CeloAdapter on-chain (Celo Sepolia)', () => {
-  const raw = process.env.PRIVATE_KEY as string
-  const pk = (raw?.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
-  const account = privateKeyToAccount(pk)
-  const publicClient = createPublicClient({
-    chain: celoSepolia,
-    transport: http(NODE_URL),
-  })
+  // Everything derived from PRIVATE_KEY has to stay inside the test body.
+  // describe.skipIf only skips *running* the tests; the callback still
+  // executes at collection, so deriving an account out here crashes the whole
+  // file when the variable is absent, as it is in CI.
+  function signer() {
+    const raw = process.env.PRIVATE_KEY as string
+    const pk = (raw.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
+    return { pk, account: privateKeyToAccount(pk) }
+  }
 
   it('sends CELO and returns a hash that confirms on chain', async () => {
+    const { pk, account } = signer()
+    const publicClient = createPublicClient({
+      chain: celoSepolia,
+      transport: http(NODE_URL),
+    })
     const adapter = new CeloAdapter({ pk, nodeUrl: NODE_URL })
     // The unauthenticated drip amount, sent to itself so only gas is spent.
     const amount = 300_000_000_000_000_000n

--- a/apps/firebase/src/celo-adapter.onchain.test.ts
+++ b/apps/firebase/src/celo-adapter.onchain.test.ts
@@ -1,0 +1,86 @@
+import { createPublicClient, formatEther, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { celoSepolia } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+import { CeloAdapter } from './celo-adapter'
+
+// Real on-chain exercise of the payout path.
+//
+// Every other test mocks `transferCelo`, so nothing otherwise proves that the
+// hash `dispatchCeloFunds` writes to `goldTxHash` is a real, resolvable
+// transaction. Opt-in because it spends gas:
+//
+// RUN_ONCHAIN_TESTS=1 PRIVATE_KEY=... yarn --cwd apps/firebase test:ci onchain
+//
+// The transfer is a self-send, so only gas is consumed.
+const NODE_URL = 'https://forno.celo-sepolia.celo-testnet.org'
+const enabled = Boolean(
+  process.env.RUN_ONCHAIN_TESTS && process.env.PRIVATE_KEY,
+)
+
+describe.skipIf(!enabled)('CeloAdapter on-chain (Celo Sepolia)', () => {
+  const raw = process.env.PRIVATE_KEY as string
+  const pk = (raw?.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
+  const account = privateKeyToAccount(pk)
+  const publicClient = createPublicClient({
+    chain: celoSepolia,
+    transport: http(NODE_URL),
+  })
+
+  it('sends CELO and returns a hash that confirms on chain', async () => {
+    const adapter = new CeloAdapter({ pk, nodeUrl: NODE_URL })
+    // The unauthenticated drip amount, sent to itself so only gas is spent.
+    const amount = 300_000_000_000_000_000n
+
+    const txHash = await adapter.transferCelo(account.address, amount)
+    expect(txHash).toMatch(/^0x[0-9a-f]{64}$/)
+
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+      timeout: 120_000,
+    })
+    const fee = receipt.gasUsed * receipt.effectiveGasPrice
+
+    // Read at explicit blocks, not `latest`: Forno is load balanced, and right
+    // after a receipt lands a replica may still serve the pre-transaction
+    // state (making a latest-vs-latest diff read as zero) or reject the block
+    // outright as out of range. Both need a retry.
+    const balanceAt = async (blockNumber: bigint) => {
+      let lastError: unknown
+      for (let i = 0; i < 15; i++) {
+        try {
+          return await publicClient.getBalance({
+            address: account.address,
+            blockNumber,
+          })
+        } catch (e) {
+          lastError = e
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+        }
+      }
+      throw lastError
+    }
+
+    const before = await balanceAt(receipt.blockNumber - 1n)
+    const after = await balanceAt(receipt.blockNumber)
+
+    console.info(`    tx        ${txHash}`)
+    console.info(`    status    ${receipt.status}`)
+    console.info(`    block     ${receipt.blockNumber}`)
+    console.info(
+      `    gas used  ${receipt.gasUsed} @ ${receipt.effectiveGasPrice} wei`,
+    )
+    console.info(`    fee       ${formatEther(fee)} CELO`)
+    console.info(
+      `    delta     ${formatEther(before - after)} CELO (self-send)`,
+    )
+    console.info(
+      `    explorer  https://celo-sepolia.blockscout.com/tx/${txHash}`,
+    )
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.transactionHash).toBe(txHash)
+    // A self-send moves no principal, so the balance falls by exactly the fee.
+    expect(before - after).toBe(fee)
+  }, 180_000)
+})

--- a/apps/firebase/src/database-helper.test.ts
+++ b/apps/firebase/src/database-helper.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DataSnapshot } from 'firebase-admin/database'
+import {
+  AuthLevel,
+  AccountPool,
+  RequestRecord,
+  RequestStatus,
+  RequestType,
+  processRequest,
+} from './database-helper'
+import { NetworkConfig } from './config'
+
+const transferCelo = vi.hoisted(() => vi.fn(async () => '0xdeadbeef'))
+vi.mock('./celo-adapter', () => ({
+  CeloAdapter: class {
+    transferCelo = transferCelo
+  },
+}))
+vi.mock('./metrics', () => ({
+  ExecutionResult: {
+    Ok: 'Ok',
+    InvalidRequestErr: 'InvalidRequestErr',
+    NoFreeAccountErr: 'NoFreeAccountErr',
+    ActionTimedOutErr: 'ActionTimedOutErr',
+    OtherErr: 'OtherErr',
+  },
+  logExecutionResult: vi.fn(),
+}))
+
+const CONFIG: NetworkConfig = {
+  nodeUrl: 'https://forno.celo-sepolia.celo-testnet.org',
+  faucetGoldAmount: 300_000_000_000_000_000n,
+  authenticatedGoldAmount: 3_000_000_000_000_000_000n,
+}
+
+function makeSnap(request: RequestRecord) {
+  const update = vi.fn(async (_patch: Record<string, unknown>) => undefined)
+  return {
+    snap: {
+      key: 'req-1',
+      val: () => request,
+      ref: { update },
+    } as unknown as DataSnapshot,
+    update,
+  }
+}
+
+/** Runs the sender against a single unlocked account. */
+function makePool() {
+  return {
+    doWithAccount: async (
+      action: (account: {
+        pk: string
+        address: string
+        locked: boolean
+      }) => Promise<void>,
+    ) => {
+      await action({ pk: '0xpk', address: '0xfrom', locked: false })
+      // ActionResult.Ok — a non-exported numeric enum, so the value is used.
+      return 0
+    },
+  } as unknown as AccountPool
+}
+
+const pendingRequest: RequestRecord = {
+  beneficiary: '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF',
+  status: RequestStatus.Pending,
+  type: RequestType.Faucet,
+  authLevel: AuthLevel.none,
+}
+
+describe('processRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transferCelo.mockResolvedValue('0xdeadbeef')
+  })
+
+  // Regression: the tx hash used to be written as `celoTxhash`, which no
+  // consumer reads, leaving the explorer link in the UI permanently empty.
+  it('records the transaction hash as goldTxHash', async () => {
+    const { snap, update } = makeSnap(pendingRequest)
+
+    await processRequest(snap, makePool(), CONFIG)
+
+    const written = Object.assign({}, ...update.mock.calls.map(([arg]) => arg))
+    expect(written.goldTxHash).toBe('0xdeadbeef')
+    expect(written).not.toHaveProperty('celoTxhash')
+  })
+
+  it('marks the request Working then Done', async () => {
+    const { snap, update } = makeSnap(pendingRequest)
+
+    await processRequest(snap, makePool(), CONFIG)
+
+    const statuses = update.mock.calls
+      .map(([patch]) => patch.status)
+      .filter(Boolean)
+    expect(statuses).toEqual([RequestStatus.Working, RequestStatus.Done])
+  })
+
+  it('sends the unauthenticated amount for an AuthLevel.none request', async () => {
+    const { snap } = makeSnap(pendingRequest)
+
+    await processRequest(snap, makePool(), CONFIG)
+
+    expect(transferCelo).toHaveBeenCalledWith(
+      pendingRequest.beneficiary,
+      CONFIG.faucetGoldAmount,
+    )
+  })
+
+  // The payout half of the elevation fix on the web side.
+  it('sends the authenticated amount for an elevated request', async () => {
+    const { snap } = makeSnap({
+      ...pendingRequest,
+      authLevel: AuthLevel.authenticated,
+    })
+
+    await processRequest(snap, makePool(), CONFIG)
+
+    expect(transferCelo).toHaveBeenCalledWith(
+      pendingRequest.beneficiary,
+      CONFIG.authenticatedGoldAmount,
+    )
+  })
+
+  it('ignores a request that is not Pending', async () => {
+    const { snap, update } = makeSnap({
+      ...pendingRequest,
+      status: RequestStatus.Done,
+    })
+
+    await processRequest(snap, makePool(), CONFIG)
+
+    expect(update).not.toHaveBeenCalled()
+    expect(transferCelo).not.toHaveBeenCalled()
+  })
+})

--- a/apps/firebase/src/database-helper.ts
+++ b/apps/firebase/src/database-helper.ts
@@ -124,7 +124,9 @@ async function dispatchCeloFunds(
   console.info(
     `req(${snap.key}): CELO Transaction Submited to mempool. txhash:${celoTxhash}`,
   )
-  await snap.ref.update({ celoTxhash })
+  // goldTxHash is the field the RequestRecord type, the database rules and the
+  // UI all read; writing celoTxhash left the explorer link permanently empty.
+  await snap.ref.update({ goldTxHash: celoTxhash })
   return celoTxhash
 }
 

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,3 +1,12 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "no-underscore-dangle": "off",
+        "import/order": "off"
+      }
+    }
+  ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@celo/abis": "^13.0.0",
@@ -37,12 +39,14 @@
     "@types/react-dom": "18.3.0",
     "eslint": "8.57.0",
     "eslint-config-next": "13.5.6",
+    "node-mocks-http": "^1.18.1",
     "postcss": "^8.5.6",
     "shadcn": "^3.2.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.13",
     "tw-animate-css": "^1.3.8",
-    "typescript": "5.5.3"
+    "typescript": "5.5.3",
+    "vitest": "^1.6.1"
   },
   "resolutions": {
     "is-arrayish": "0.3.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run",
+    "smoke:api-key": "node scripts/smoke-api-key.mjs"
   },
   "dependencies": {
     "@celo/abis": "^13.0.0",

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -109,6 +109,14 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
                 &bull; You may faucet 10 times a day if <i>authenticated</i>,
                 for 10 times the amount of unauthenticated requests.
               </p>
+              <p className={inter.className}>
+                &bull; Requests made with an{' '}
+                <Link className="underline" href="/keys">
+                  API key
+                </Link>{' '}
+                skip the captcha and draw from the same daily allowance as your
+                GitHub sign-in.
+              </p>
             </div>
           </Card>
           <Card className={styles.card}>

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -60,6 +60,13 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
                 </>
               )}
               <small className={inter.className}>
+                &bull; Scripting or building an agent?{' '}
+                <Link className="underline" href="/keys">
+                  Create an API key
+                </Link>{' '}
+                to skip the captcha
+              </small>
+              <small className={inter.className}>
                 &bull; Need <b>USDC</b>? Get tokens at{' '}
                 <Link className="underline" href="https://faucet.circle.com/">
                   faucet.circle.com

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -39,11 +39,15 @@ export const authOptions: AuthOptions = {
       return session
     },
   },
+  // Long enough to mint and copy an API key on /keys. Sessions only select the
+  // authenticated tier; the durable control is the per-identity rate-limit
+  // bucket keyed on sha256(email), which survives across sessions, so a longer
+  // session grants no extra funds.
   session: {
-    maxAge: 2 * 60, // 2 minutes in seconds
+    maxAge: 15 * 60, // 15 minutes in seconds
   },
   jwt: {
-    maxAge: 60, // seconds
+    maxAge: 15 * 60, // seconds
   },
 }
 

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -132,6 +132,10 @@ export default async function handler(
           verified.reason === 'disabled'
             ? 'Programmatic access is temporarily disabled'
             : 'Invalid or expired API key',
+        error:
+          verified.reason === 'disabled'
+            ? 'api_key_disabled'
+            : 'invalid_api_key',
       })
       return
     }
@@ -217,10 +221,22 @@ export default async function handler(
         network,
         keyId,
       })
-      res.status(403).json({
-        status: RequestStatus.Failed,
-        message: 'Fauceting denied. Please check the faucet rules below.',
-      })
+      // 429 on the key path matches the CDP faucet and is the correct
+      // semantic for a programmatic caller; the browser keeps its existing
+      // 403 so the on-page copy and any existing consumer are untouched.
+      if (channel === AdmissionChannel.apiKey) {
+        res.setHeader('Retry-After', '86400')
+        res.status(429).json({
+          status: RequestStatus.Failed,
+          message: `Rate limit exceeded (${bucket ?? 'unknown'}). See the faucet rules.`,
+          error: 'faucet_limit_exceeded',
+        })
+      } else {
+        res.status(403).json({
+          status: RequestStatus.Failed,
+          message: 'Fauceting denied. Please check the faucet rules below.',
+        })
+      }
     } else {
       throw new Error(reason)
     }

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -113,7 +113,27 @@ export default async function handler(
       return
     }
 
-    const verified = await verifyKey(token)
+    // verifyKey reaches Redis and throws when FAUCET_API_KEY_PEPPER is absent.
+    // Without this guard the rejection escapes the handler as an opaque 500.
+    let verified
+    try {
+      verified = await verifyKey(token)
+    } catch (e) {
+      console.error('API key verification failed', e)
+      logAdmission({
+        channel,
+        outcome: AdmissionOutcome.invalidKey,
+        network,
+        ipHash,
+      })
+      res.setHeader('Retry-After', '30')
+      res.status(503).json({
+        status: RequestStatus.Failed,
+        message: 'Key verification is unavailable, retry shortly',
+      })
+      return
+    }
+
     if (!verified.ok) {
       // Deliberately no fall-through to the captcha: that would let an attacker
       // probe key space while still being served.

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -2,79 +2,233 @@ import { ipAddress } from '@vercel/functions'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Session } from 'next-auth'
 import { getServerSession } from 'next-auth/next'
-import { Hex, sha256 } from 'viem'
-import { sendRequest } from '../../utils/firebase.serverside'
+import { Hex, isAddress, sha256 } from 'viem'
 import { authOptions } from './auth/[...nextauth]'
+import { sendRequest } from 'utils/firebase.serverside'
 import { captchaVerify } from 'utils/captcha-verify'
+import { verifyKey } from 'utils/api-key'
+import {
+  AdmissionChannel,
+  AdmissionOutcome,
+  hashIp,
+  logAdmission,
+  logEnqueued,
+  logRateLimited,
+} from 'utils/metrics'
 import { AuthLevel, FaucetAPIResponse, networks, RequestStatus } from 'types'
+
+function bearerToken(req: NextApiRequest): string | undefined {
+  const header = req.headers.authorization
+  if (!header) {
+    return undefined
+  }
+  const [scheme, ...rest] = header.split(' ')
+  if (scheme?.toLowerCase() !== 'bearer') {
+    return undefined
+  }
+  const token = rest.join(' ').trim()
+  return token || undefined
+}
+
+/** Networks that accept API-key auth. There must be no mainnet exposure. */
+function keyPathAllows(network: string): boolean {
+  const allowed = process.env.FAUCET_API_KEY_NETWORKS?.split(',')
+    .map((n) => n.trim())
+    .filter(Boolean)
+  return allowed?.length
+    ? allowed.includes(network)
+    : network === 'celo-sepolia'
+}
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FaucetAPIResponse>,
 ) {
-  let authLevel = AuthLevel.none
-  let session: Session | null | undefined
-  try {
-    session = await getServerSession(req, res, authOptions)
-    if (session) {
-      authLevel = AuthLevel.authenticated
-    }
-  } catch (e) {
-    console.error('Authentication check failed', e)
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({
+      status: RequestStatus.Failed,
+      message: `Method ${req.method} not allowed`,
+    })
+    return
   }
 
-  const { captchaToken, beneficiary, network } = req.body
+  const { captchaToken, beneficiary, network } = req.body ?? {}
+  const token = bearerToken(req)
+  const channel = token ? AdmissionChannel.apiKey : AdmissionChannel.browser
 
   if (!networks.includes(network)) {
+    logAdmission({
+      channel,
+      outcome: AdmissionOutcome.badRequest,
+      network,
+    })
     res.status(400).json({
       status: RequestStatus.Failed,
       message: `Invalid network: ${network}`,
     })
     return
   }
+
+  // Without this, an invalid address throws inside sendRequest and surfaces as
+  // a generic 404, which a programmatic caller cannot act on.
+  if (typeof beneficiary !== 'string' || !isAddress(beneficiary)) {
+    logAdmission({
+      channel,
+      outcome: AdmissionOutcome.badRequest,
+      network,
+    })
+    res.status(400).json({
+      status: RequestStatus.Failed,
+      message: 'Invalid beneficiary address',
+    })
+    return
+  }
+
   const headers = new Headers()
   for (const [key, value] of Object.entries(req.headers)) {
     headers.set(key, value as string)
   }
+  const ip =
+    ipAddress(headers) || (req.headers['x-forwarded-for'] as string | undefined)
+  const ipHash = hashIp(ip)
 
-  const captchaResponse = await captchaVerify(captchaToken)
-  if (captchaResponse.success) {
-    try {
-      const { key, reason } = await sendRequest(
-        beneficiary,
-        true,
+  let authLevel = AuthLevel.none
+  let userId: string | undefined
+  let keyId: string | undefined
+
+  if (token) {
+    // A key stands in for the GitHub identity, so the session is not consulted:
+    // it would be a wasted JWT verify and an identity with no defined bucket.
+    if (!keyPathAllows(network)) {
+      logAdmission({
+        channel,
+        outcome: AdmissionOutcome.badRequest,
         network,
-        authLevel,
-        ipAddress(headers) ||
-          (req.headers['x-forwarded-for'] as string | undefined),
-        session?.user?.email ? sha256(session.user.email as Hex) : undefined,
-      )
-
-      if (key) {
-        res.status(200).json({ status: RequestStatus.Pending, key })
-      } else if (reason === 'rate_limited') {
-        res.status(403).json({
-          status: RequestStatus.Failed,
-          message: 'Fauceting denied. Please check the faucet rules below.',
-        })
-      } else {
-        throw new Error(reason)
-      }
-    } catch (error) {
-      console.error(error)
-      res.status(404).json({
-        status: RequestStatus.Failed,
-        message: 'Error while fauceting',
       })
+      res.status(400).json({
+        status: RequestStatus.Failed,
+        message: `API key access is not enabled for ${network}`,
+      })
+      return
     }
+
+    const verified = await verifyKey(token)
+    if (!verified.ok) {
+      // Deliberately no fall-through to the captcha: that would let an attacker
+      // probe key space while still being served.
+      logAdmission({
+        channel,
+        outcome:
+          verified.reason === 'disabled'
+            ? AdmissionOutcome.keyDisabled
+            : AdmissionOutcome.invalidKey,
+        network,
+        ipHash,
+      })
+      res.status(401).json({
+        status: RequestStatus.Failed,
+        message:
+          verified.reason === 'disabled'
+            ? 'Programmatic access is temporarily disabled'
+            : 'Invalid or expired API key',
+      })
+      return
+    }
+
+    // Same identity and tier as signing in with GitHub, proven differently.
+    authLevel = AuthLevel.authenticated
+    userId = verified.ownerHash
+    keyId = verified.keyId
+
+    logAdmission({
+      channel,
+      outcome: AdmissionOutcome.admitted,
+      network,
+      authLevel,
+      keyId,
+      ipHash,
+    })
   } else {
-    console.error(
-      'Faucet Failed due to Recaptcha',
-      captchaResponse['error-codes'],
-    )
-    res.status(401).json({
+    let session: Session | null | undefined
+    try {
+      session = await getServerSession(req, res, authOptions)
+      if (session) {
+        authLevel = AuthLevel.authenticated
+      }
+    } catch (e) {
+      console.error('Authentication check failed', e)
+    }
+    userId = session?.user?.email
+      ? sha256(session.user.email as Hex)
+      : undefined
+
+    const captchaResponse = await captchaVerify(captchaToken)
+    if (!captchaResponse.success) {
+      logAdmission({
+        channel,
+        outcome: AdmissionOutcome.captchaFailed,
+        network,
+        ipHash,
+        captchaScore: captchaResponse.score,
+        errorCodes: captchaResponse['error-codes'],
+      })
+      console.error(
+        'Faucet Failed due to Recaptcha',
+        captchaResponse['error-codes'],
+      )
+      res.status(401).json({
+        status: RequestStatus.Failed,
+        message: captchaResponse['error-codes']?.toString() || 'unknown',
+      })
+      return
+    }
+
+    logAdmission({
+      channel,
+      outcome: AdmissionOutcome.admitted,
+      network,
+      authLevel,
+      ipHash,
+      captchaScore: captchaResponse.score,
+    })
+  }
+
+  try {
+    const { key, reason, bucket, count, limit } = await sendRequest({
+      address: beneficiary,
+      skipStables: true,
+      network,
+      authLevel,
+      channel,
+      ip,
+      userId,
+    })
+
+    if (key) {
+      logEnqueued({ channel, key, authLevel, network, keyId })
+      res.status(200).json({ status: RequestStatus.Pending, key })
+    } else if (reason === 'rate_limited') {
+      logRateLimited({
+        channel,
+        bucket: bucket ?? 'unknown',
+        count: count ?? 0,
+        limit: limit ?? 0,
+        network,
+        keyId,
+      })
+      res.status(403).json({
+        status: RequestStatus.Failed,
+        message: 'Fauceting denied. Please check the faucet rules below.',
+      })
+    } else {
+      throw new Error(reason)
+    }
+  } catch (error) {
+    console.error(error)
+    res.status(404).json({
       status: RequestStatus.Failed,
-      message: captchaResponse['error-codes']?.toString() || 'unknown',
+      message: 'Error while fauceting',
     })
   }
 }

--- a/apps/web/pages/api/faucet.ts
+++ b/apps/web/pages/api/faucet.ts
@@ -4,7 +4,11 @@ import { Session } from 'next-auth'
 import { getServerSession } from 'next-auth/next'
 import { Hex, isAddress, sha256 } from 'viem'
 import { authOptions } from './auth/[...nextauth]'
-import { sendRequest } from 'utils/firebase.serverside'
+import {
+  PROGRAMMATIC_BURST_LIMIT,
+  PROGRAMMATIC_GLOBAL_LIMIT,
+  sendRequest,
+} from 'utils/firebase.serverside'
 import { captchaVerify } from 'utils/captcha-verify'
 import { verifyKey } from 'utils/api-key'
 import {
@@ -245,7 +249,13 @@ export default async function handler(
       // semantic for a programmatic caller; the browser keeps its existing
       // 403 so the on-page copy and any existing consumer are untouched.
       if (channel === AdmissionChannel.apiKey) {
-        res.setHeader('Retry-After', '86400')
+        // The burst window clears in ten minutes; sending the daily figure
+        // would park an agent for a day over a limit that has already gone.
+        const retryAfter =
+          bucket === 'programmatic-burst'
+            ? PROGRAMMATIC_BURST_LIMIT.timePeriodInSeconds
+            : PROGRAMMATIC_GLOBAL_LIMIT.timePeriodInSeconds
+        res.setHeader('Retry-After', String(retryAfter))
         res.status(429).json({
           status: RequestStatus.Failed,
           message: `Rate limit exceeded (${bucket ?? 'unknown'}). See the faucet rules.`,

--- a/apps/web/pages/api/keys/[keyId].ts
+++ b/apps/web/pages/api/keys/[keyId].ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { revokeKey } from 'utils/api-key'
+import { getOwnerHash } from 'utils/session-owner'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ message: string }>,
+) {
+  if (req.method !== 'DELETE') {
+    res.setHeader('Allow', 'DELETE')
+    res.status(405).json({ message: `Method ${req.method} not allowed` })
+    return
+  }
+
+  const ownerHash = await getOwnerHash(req, res)
+  if (!ownerHash) {
+    res.status(401).json({ message: 'Sign in with GitHub to manage API keys' })
+    return
+  }
+
+  const keyId = String(req.query.keyId ?? '')
+
+  try {
+    // Returns false for someone else's key as well as a missing one, so this
+    // endpoint cannot be used to probe which key ids exist.
+    const revoked = await revokeKey(keyId, ownerHash)
+    if (!revoked) {
+      res.status(404).json({ message: 'No such key' })
+      return
+    }
+    console.info(JSON.stringify({ event: 'celo/faucet/key_revoked', keyId }))
+    res.status(200).json({ message: 'Key revoked' })
+  } catch (error) {
+    console.error('Failed to revoke API key', error)
+    res.status(500).json({ message: 'Could not revoke the key' })
+  }
+}

--- a/apps/web/pages/api/keys/index.ts
+++ b/apps/web/pages/api/keys/index.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { ApiKeyRecord, KEY_TTL_DAYS, MAX_KEYS_PER_OWNER } from 'types'
+import { listKeysForOwner, mintKey } from 'utils/api-key'
+import { getOwnerHash } from 'utils/session-owner'
+
+export type KeysAPIResponse =
+  | { keys: ApiKeyRecord[] }
+  /** `key` is returned exactly once, at creation, and never stored in full. */
+  | { key: string; record: ApiKeyRecord }
+  | { message: string }
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<KeysAPIResponse>,
+) {
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.setHeader('Allow', 'GET, POST')
+    res.status(405).json({ message: `Method ${req.method} not allowed` })
+    return
+  }
+
+  const ownerHash = await getOwnerHash(req, res)
+  if (!ownerHash) {
+    res.status(401).json({ message: 'Sign in with GitHub to manage API keys' })
+    return
+  }
+
+  try {
+    if (req.method === 'GET') {
+      res.status(200).json({ keys: await listKeysForOwner(ownerHash) })
+      return
+    }
+
+    const label = String(req.body?.label ?? '').trim()
+    if (!label) {
+      res.status(400).json({ message: 'A label is required' })
+      return
+    }
+
+    const { key, record } = await mintKey(ownerHash, label)
+    console.info(
+      JSON.stringify({
+        event: 'celo/faucet/key_minted',
+        keyId: record.keyId,
+        expiresAt: record.expiresAt,
+      }),
+    )
+    res.status(201).json({ key, record })
+  } catch (error) {
+    // mintKey throws a user-facing message when the owner is at their cap.
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    const atCap = message.includes('already have')
+    if (!atCap) {
+      console.error('Failed to handle API key request', error)
+    }
+    res.status(atCap ? 409 : 500).json({
+      message: atCap
+        ? message
+        : `Could not create a key. Keys last ${KEY_TTL_DAYS} days and you may hold ${MAX_KEYS_PER_OWNER}.`,
+    })
+  }
+}

--- a/apps/web/pages/api/status.ts
+++ b/apps/web/pages/api/status.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { networks, RequestStatus } from 'types'
+import { getRequestRecord } from 'utils/firebase.serverside'
+
+export type StatusAPIResponse =
+  | {
+      status: RequestStatus
+      beneficiary?: string
+      txHash?: string
+    }
+  | { message: string }
+
+/**
+ * HTTP view of a queued request.
+ *
+ * The browser subscribes to the Realtime Database over a websocket, which a
+ * programmatic caller cannot reasonably do; without this endpoint an agent has
+ * no way to tell whether a payout landed.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<StatusAPIResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    res.status(405).json({ message: `Method ${req.method} not allowed` })
+    return
+  }
+
+  const key = String(req.query.key ?? '')
+  const network = String(req.query.network ?? '')
+
+  if (!networks.includes(network as (typeof networks)[number])) {
+    res.status(400).json({ message: `Invalid network: ${network}` })
+    return
+  }
+  if (!key) {
+    res.status(400).json({ message: 'Missing request key' })
+    return
+  }
+
+  try {
+    const record = await getRequestRecord(
+      key,
+      network as (typeof networks)[number],
+    )
+    if (!record) {
+      res.status(404).json({ message: 'No such request' })
+      return
+    }
+
+    res.setHeader('Cache-Control', 'no-store')
+    res.status(200).json({
+      status: record.status,
+      beneficiary: record.beneficiary,
+      // goldTxHash is the current field; celoTxhash is read so requests queued
+      // before that fix still resolve.
+      txHash: record.goldTxHash ?? record.celoTxhash,
+    })
+  } catch (error) {
+    console.error('Failed to read request status', error)
+    res.status(500).json({ message: 'Could not read request status' })
+  }
+}

--- a/apps/web/pages/keys.tsx
+++ b/apps/web/pages/keys.tsx
@@ -13,7 +13,7 @@ import {
 } from '../@/components/ui/card'
 import { Input } from '../@/components/ui/input'
 import { Label } from '../@/components/ui/label'
-import { GitHubAuth } from 'components/github-auth'
+import { FaucetHeader } from 'components/faucet-header'
 import styles from 'styles/Home.module.css'
 import { ApiKeyRecord, KEY_TTL_DAYS, MAX_KEYS_PER_OWNER } from 'types'
 import { inter } from 'utils/inter'
@@ -25,6 +25,7 @@ const ApiKeys: NextPage = () => {
   const [keys, setKeys] = useState<ApiKeyRecord[]>([])
   const [label, setLabel] = useState('')
   const [freshKey, setFreshKey] = useState<string>()
+  const [copied, setCopied] = useState(false)
   const [error, setError] = useState<string>()
   const [busy, setBusy] = useState(false)
 
@@ -44,6 +45,7 @@ const ApiKeys: NextPage = () => {
   const create = useCallback(async () => {
     setBusy(true)
     setError(undefined)
+    setCopied(false)
     try {
       const res = await fetch('/api/keys', {
         method: 'POST',
@@ -66,6 +68,14 @@ const ApiKeys: NextPage = () => {
     }
   }, [label, load])
 
+  const copy = useCallback(async () => {
+    if (!freshKey) {
+      return
+    }
+    await navigator.clipboard.writeText(freshKey)
+    setCopied(true)
+  }, [freshKey])
+
   const revoke = useCallback(
     async (keyId: string) => {
       setBusy(true)
@@ -79,6 +89,8 @@ const ApiKeys: NextPage = () => {
     [load],
   )
 
+  const atCap = keys.length >= MAX_KEYS_PER_OWNER
+
   return (
     <>
       <Head>
@@ -91,26 +103,33 @@ const ApiKeys: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className={styles.main}>
-        <Card className="w-full max-w-xl items-stretch">
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Faucet API Keys</CardTitle>
-            <GitHubAuth />
+        <FaucetHeader network="celo-sepolia" isOutOfCELO={false} />
+
+        <Card className="w-full max-w-lg items-stretch">
+          <CardHeader>
+            <CardTitle>API Keys</CardTitle>
           </CardHeader>
 
           <CardContent className="flex flex-col gap-4">
             <p className={`${inter.className} text-sm`}>
               An API key lets scripts and AI agents call the faucet without
-              solving a captcha. Requests share your GitHub account&apos;s daily
-              allowance, so a key changes how you prove who you are, not how
-              much you can request.
+              solving a captcha. Requests draw on your GitHub account&apos;s
+              daily allowance, so a key changes how you prove who you are, not
+              how much you can request.
             </p>
 
-            {status === 'loading' && <p className="text-sm">Loading…</p>}
+            {status === 'loading' && (
+              <small className={inter.className}>Loading&hellip;</small>
+            )}
 
             {status !== 'loading' && !session && (
-              <p className={`${inter.className} text-sm`}>
-                Sign in with GitHub to create a key.
-              </p>
+              <small className={inter.className}>
+                &bull;{' '}
+                <Link className="underline" href="/api/auth/signin/github">
+                  Authenticate with GitHub
+                </Link>{' '}
+                to create a key
+              </small>
             )}
 
             {session && (
@@ -123,70 +142,87 @@ const ApiKeys: NextPage = () => {
                       value={label}
                       placeholder="e.g. local celo-mcp"
                       maxLength={60}
+                      disabled={atCap}
                       onChange={(e) => setLabel(e.target.value)}
                     />
                     <Button
                       onClick={create}
-                      disabled={busy || !label.trim()}
+                      disabled={busy || atCap || !label.trim()}
                       type="button"
                     >
                       Create
                     </Button>
                   </div>
+                  {atCap && (
+                    <small className={inter.className}>
+                      You are at the limit of {MAX_KEYS_PER_OWNER} keys. Revoke
+                      one to create another.
+                    </small>
+                  )}
                 </div>
 
                 {error && (
-                  <p className="text-sm text-red-500" role="alert">
+                  <small className={inter.className} role="alert">
                     {error}
-                  </p>
+                  </small>
                 )}
 
                 {freshKey && (
-                  <div className="flex flex-col gap-1 rounded-md border p-3">
+                  <div className="flex flex-col gap-2 border-2 border-border p-3">
                     <b className="text-sm">
-                      Copy this key now. It will not be shown again.
+                      Copy this key now — it is not shown again.
                     </b>
                     <code className="break-all text-xs">{freshKey}</code>
+                    <div className="flex items-center gap-2">
+                      <Button type="button" variant="neutral" onClick={copy}>
+                        Copy key
+                      </Button>
+                      <small aria-live="polite" className={inter.className}>
+                        {copied ? 'Copied to clipboard' : ''}
+                      </small>
+                    </div>
                   </div>
                 )}
 
                 <div className="flex flex-col gap-2">
-                  {keys.length === 0 && (
+                  {keys.length === 0 ? (
                     <small className={inter.className}>
                       You have no active keys.
                     </small>
-                  )}
-                  {keys.map((key) => (
-                    <div
-                      key={key.keyId}
-                      className="flex items-center justify-between gap-2 rounded-md border p-2"
-                    >
-                      <div className="flex flex-col">
-                        <span className="text-sm">{key.label}</span>
-                        <small className="text-xs opacity-70">
-                          {key.keyId} &bull; expires {formatDate(key.expiresAt)}
-                        </small>
-                      </div>
-                      <Button
-                        variant="neutral"
-                        type="button"
-                        disabled={busy}
-                        onClick={() => revoke(key.keyId)}
+                  ) : (
+                    keys.map((key) => (
+                      <div
+                        key={key.keyId}
+                        className="flex items-center justify-between gap-2 border-2 border-border p-2"
                       >
-                        Revoke
-                      </Button>
-                    </div>
-                  ))}
+                        <div className="flex flex-col">
+                          <span className="text-sm">{key.label}</span>
+                          <small className="text-xs opacity-70">
+                            {key.keyId} &bull; expires{' '}
+                            {formatDate(key.expiresAt)}
+                          </small>
+                        </div>
+                        <Button
+                          variant="neutral"
+                          type="button"
+                          disabled={busy}
+                          onClick={() => revoke(key.keyId)}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    ))
+                  )}
                 </div>
               </>
             )}
           </CardContent>
 
-          <CardFooter>
-            <div className="flex flex-col gap-1 text-sm">
+          <CardFooter className="flex-col gap-2">
+            <div className="mt-4 text-sm flex flex-col gap-0.5 items-start">
               <small className={inter.className}>
-                &bull; You can hold up to {MAX_KEYS_PER_OWNER} keys. Keys expire
-                after {KEY_TTL_DAYS} days.
+                &bull; You may hold {MAX_KEYS_PER_OWNER} keys. They expire after{' '}
+                {KEY_TTL_DAYS} days.
               </small>
               <small className={inter.className}>
                 &bull; Never commit a key. Keys found in public repositories are
@@ -201,6 +237,83 @@ const ApiKeys: NextPage = () => {
             </div>
           </CardFooter>
         </Card>
+
+        <footer className={styles.grid}>
+          <Card className={styles.card}>
+            <h3 className={inter.className}>Using your key</h3>
+            <div className="flex flex-col gap-1">
+              <p className={inter.className}>
+                Send it as a bearer token and leave out the captcha:
+              </p>
+              <pre className="overflow-x-auto text-xs">
+                <code>{`curl -X POST https://faucet.celo.org/api/faucet \\
+  -H "Authorization: Bearer $CELO_FAUCET_API_KEY" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"beneficiary":"0x…","network":"celo-sepolia"}'`}</code>
+              </pre>
+            </div>
+          </Card>
+
+          <Card className={styles.card}>
+            <h3 className={inter.className}>Limits</h3>
+            <div className="flex flex-col gap-1">
+              <p className={inter.className}>
+                &bull; Keyed requests share your GitHub account&apos;s allowance
+                of 10 per day.
+              </p>
+              <p className={inter.className}>
+                &bull; Holding two keys does not double it.
+              </p>
+              <p className={inter.className}>
+                &bull; Celo Sepolia only. There is no mainnet access.
+              </p>
+            </div>
+          </Card>
+
+          <Card className={styles.card}>
+            <h3 className={inter.className}>Check the outcome</h3>
+            <div className="flex flex-col gap-1">
+              <p className={inter.className}>
+                A request returns a key. Poll it for the transaction hash:
+              </p>
+              <pre className="whitespace-pre-wrap break-all text-xs">
+                <code>{`GET /api/status?key=<key>&network=celo-sepolia`}</code>
+              </pre>
+            </div>
+          </Card>
+
+          <Card className={styles.card}>
+            <a
+              href="https://github.com/celo-org/faucet#programmatic-access-api-keys"
+              target="_blank"
+              tabIndex={0}
+              rel="noopener noreferrer"
+            >
+              <h3 className={inter.className}>
+                Read the docs <span>&rarr;</span>
+              </h3>
+              <p className={inter.className}>
+                Response codes, rate limits and the status endpoint
+              </p>
+            </a>
+          </Card>
+
+          <Card className={styles.card}>
+            <a
+              href="https://chat.celo.org"
+              target="_blank"
+              tabIndex={0}
+              rel="noopener noreferrer"
+            >
+              <h3 className={inter.className}>
+                Ask questions <span>&rarr;</span>
+              </h3>
+              <p className={inter.className}>
+                Chat with the Celo community on Discord
+              </p>
+            </a>
+          </Card>
+        </footer>
       </main>
     </>
   )

--- a/apps/web/pages/keys.tsx
+++ b/apps/web/pages/keys.tsx
@@ -1,0 +1,209 @@
+import { NextPage } from 'next'
+import { useSession } from 'next-auth/react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '../@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../@/components/ui/card'
+import { Input } from '../@/components/ui/input'
+import { Label } from '../@/components/ui/label'
+import { GitHubAuth } from 'components/github-auth'
+import styles from 'styles/Home.module.css'
+import { ApiKeyRecord, KEY_TTL_DAYS, MAX_KEYS_PER_OWNER } from 'types'
+import { inter } from 'utils/inter'
+
+const formatDate = (ms: number) => new Date(ms).toISOString().slice(0, 10)
+
+const ApiKeys: NextPage = () => {
+  const { data: session, status } = useSession()
+  const [keys, setKeys] = useState<ApiKeyRecord[]>([])
+  const [label, setLabel] = useState('')
+  const [freshKey, setFreshKey] = useState<string>()
+  const [error, setError] = useState<string>()
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    const res = await fetch('/api/keys')
+    if (res.ok) {
+      setKeys((await res.json()).keys)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (session) {
+      load().catch(console.error)
+    }
+  }, [session, load])
+
+  const create = useCallback(async () => {
+    setBusy(true)
+    setError(undefined)
+    try {
+      const res = await fetch('/api/keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.message)
+        return
+      }
+      // Shown once; the server only ever stored a hash of it.
+      setFreshKey(data.key)
+      setLabel('')
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setBusy(false)
+    }
+  }, [label, load])
+
+  const revoke = useCallback(
+    async (keyId: string) => {
+      setBusy(true)
+      try {
+        await fetch(`/api/keys/${keyId}`, { method: 'DELETE' })
+        await load()
+      } finally {
+        setBusy(false)
+      }
+    },
+    [load],
+  )
+
+  return (
+    <>
+      <Head>
+        <title>Faucet API Keys</title>
+        <meta
+          name="description"
+          content="Create an API key for programmatic access to the Celo faucet"
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main className={styles.main}>
+        <Card className="w-full max-w-xl items-stretch">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Faucet API Keys</CardTitle>
+            <GitHubAuth />
+          </CardHeader>
+
+          <CardContent className="flex flex-col gap-4">
+            <p className={`${inter.className} text-sm`}>
+              An API key lets scripts and AI agents call the faucet without
+              solving a captcha. Requests share your GitHub account&apos;s daily
+              allowance, so a key changes how you prove who you are, not how
+              much you can request.
+            </p>
+
+            {status === 'loading' && <p className="text-sm">Loading…</p>}
+
+            {status !== 'loading' && !session && (
+              <p className={`${inter.className} text-sm`}>
+                Sign in with GitHub to create a key.
+              </p>
+            )}
+
+            {session && (
+              <>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="label">Key name</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="label"
+                      value={label}
+                      placeholder="e.g. local celo-mcp"
+                      maxLength={60}
+                      onChange={(e) => setLabel(e.target.value)}
+                    />
+                    <Button
+                      onClick={create}
+                      disabled={busy || !label.trim()}
+                      type="button"
+                    >
+                      Create
+                    </Button>
+                  </div>
+                </div>
+
+                {error && (
+                  <p className="text-sm text-red-500" role="alert">
+                    {error}
+                  </p>
+                )}
+
+                {freshKey && (
+                  <div className="flex flex-col gap-1 rounded-md border p-3">
+                    <b className="text-sm">
+                      Copy this key now. It will not be shown again.
+                    </b>
+                    <code className="break-all text-xs">{freshKey}</code>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  {keys.length === 0 && (
+                    <small className={inter.className}>
+                      You have no active keys.
+                    </small>
+                  )}
+                  {keys.map((key) => (
+                    <div
+                      key={key.keyId}
+                      className="flex items-center justify-between gap-2 rounded-md border p-2"
+                    >
+                      <div className="flex flex-col">
+                        <span className="text-sm">{key.label}</span>
+                        <small className="text-xs opacity-70">
+                          {key.keyId} &bull; expires {formatDate(key.expiresAt)}
+                        </small>
+                      </div>
+                      <Button
+                        variant="neutral"
+                        type="button"
+                        disabled={busy}
+                        onClick={() => revoke(key.keyId)}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </CardContent>
+
+          <CardFooter>
+            <div className="flex flex-col gap-1 text-sm">
+              <small className={inter.className}>
+                &bull; You can hold up to {MAX_KEYS_PER_OWNER} keys. Keys expire
+                after {KEY_TTL_DAYS} days.
+              </small>
+              <small className={inter.className}>
+                &bull; Never commit a key. Keys found in public repositories are
+                revoked without notice.
+              </small>
+              <small className={inter.className}>
+                &bull;{' '}
+                <Link className="underline" href="/celo-sepolia">
+                  Back to the faucet
+                </Link>
+              </small>
+            </div>
+          </CardFooter>
+        </Card>
+      </main>
+    </>
+  )
+}
+
+export default ApiKeys

--- a/apps/web/scripts/smoke-api-key.mjs
+++ b/apps/web/scripts/smoke-api-key.mjs
@@ -1,0 +1,152 @@
+/**
+ * End-to-end smoke test for the API-key faucet path.
+ *
+ * Pure HTTP against a running deployment, so it needs no repo credentials and
+ * no local build. Mint a key at <url>/keys first, then export it.
+ *
+ * Usage:
+ *   export FAUCET_API_KEY=cfk_...
+ *   node apps/web/scripts/smoke-api-key.mjs \
+ *     --url https://<deployment> --beneficiary 0xYourAddress
+ *
+ * Exits non-zero if any check fails. The key is never printed.
+ */
+
+const USAGE = `Usage:
+  export FAUCET_API_KEY=cfk_...
+  node apps/web/scripts/smoke-api-key.mjs --url <deployment> --beneficiary 0x... [--network celo-sepolia]`
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`)
+  const value = i === -1 ? fallback : process.argv[i + 1]
+  if (!value) {
+    console.error(`Missing required --${name}\n\n${USAGE}`)
+    process.exit(1)
+  }
+  return value
+}
+
+const BASE = arg('url').replace(/\/$/, '')
+const NETWORK = arg('network', 'celo-sepolia')
+const BENEFICIARY = arg('beneficiary')
+const CREDENTIAL = process.env.FAUCET_API_KEY
+
+if (!CREDENTIAL) {
+  console.error('Set FAUCET_API_KEY to a key minted at <url>/keys')
+  process.exit(1)
+}
+
+let failures = 0
+function check(label, ok, detail = '') {
+  console.info(
+    `${ok ? 'PASS' : 'FAIL'}  ${detail ? `${label} — ${detail}` : label}`,
+  )
+  if (!ok) {
+    failures++
+  }
+}
+
+async function post(body, credential) {
+  const res = await fetch(`${BASE}/api/faucet`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(credential ? { Authorization: `Bearer ${credential}` } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: await res.json().catch(() => ({})) }
+}
+
+const request = { beneficiary: BENEFICIARY, network: NETWORK }
+
+async function main() {
+  console.info(
+    `Target ${BASE}  network=${NETWORK}  beneficiary=${BENEFICIARY}\n`,
+  )
+
+  const unissued = `cfk_prd_deadbeefcafe_${'a'.repeat(43)}`
+  check(
+    'unissued key rejected with 401',
+    (await post(request, unissued)).status === 401,
+  )
+
+  const noAuth = await post(request)
+  check(
+    'no credential is rejected (captcha path)',
+    noAuth.status === 401,
+    `got ${noAuth.status}`,
+  )
+
+  const badAddr = await post({ ...request, beneficiary: 'nope' }, CREDENTIAL)
+  check(
+    'invalid address rejected with 400',
+    badAddr.status === 400,
+    `got ${badAddr.status}`,
+  )
+
+  const badNet = await post({ ...request, network: 'celo-mainnet' }, CREDENTIAL)
+  check(
+    'unknown network rejected with 400',
+    badNet.status === 400,
+    `got ${badNet.status}`,
+  )
+
+  const wrongMethod = await fetch(`${BASE}/api/faucet`, { method: 'GET' })
+  check(
+    'GET rejected with 405',
+    wrongMethod.status === 405,
+    `got ${wrongMethod.status}`,
+  )
+
+  const ok = await post(request, CREDENTIAL)
+  check(
+    'valid key accepted with 200 and no captcha',
+    ok.status === 200,
+    `got ${ok.status} ${JSON.stringify(ok.body)}`,
+  )
+
+  const requestKey = ok.body?.key
+  check('response carries a request key', Boolean(requestKey))
+
+  if (requestKey) {
+    let status = ''
+    let txHash
+    for (let i = 0; i < 30; i++) {
+      const res = await fetch(
+        `${BASE}/api/status?key=${encodeURIComponent(requestKey)}&network=${NETWORK}`,
+      )
+      const data = await res.json()
+      status = data.status ?? ''
+      txHash = data.txHash
+      if (status === 'Done' || status === 'Failed') {
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
+    check(
+      'payout reached Done',
+      status === 'Done',
+      `final status ${status || 'none'}`,
+    )
+    check(
+      'status endpoint returns a tx hash',
+      Boolean(txHash),
+      txHash ?? 'none',
+    )
+    if (txHash) {
+      console.info(`      https://celo-sepolia.blockscout.com/tx/${txHash}`)
+    }
+  }
+
+  console.info(
+    `\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}`,
+  )
+  console.info('Revoke the key at ' + BASE + '/keys when you are done.')
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/web/scripts/smoke-api-key.mjs
+++ b/apps/web/scripts/smoke-api-key.mjs
@@ -139,6 +139,19 @@ async function main() {
     }
   }
 
+  const limited = await post(request, CREDENTIAL)
+  if (limited.status === 429) {
+    check(
+      'rate limit returns 429 with faucet_limit_exceeded',
+      limited.body?.error === 'faucet_limit_exceeded',
+      JSON.stringify(limited.body),
+    )
+  } else {
+    console.info(
+      `SKIP  rate-limit check — allowance not exhausted (got ${limited.status})`,
+    )
+  }
+
   console.info(
     `\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}`,
   )

--- a/apps/web/tests/faucet.test.ts
+++ b/apps/web/tests/faucet.test.ts
@@ -288,6 +288,20 @@ describe('POST /api/faucet — API key path', () => {
     expect(res._getJSONData().error).toBe('api_key_disabled')
   })
 
+  // Regression: verifyKey reaches Redis and throws when the pepper is
+  // missing; that rejection used to escape the handler as an opaque 500.
+  it('returns 503 rather than throwing when key verification fails', async () => {
+    verifyKey.mockRejectedValue(
+      new Error('Missing in env: FAUCET_API_KEY_PEPPER'),
+    )
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+
+    await expect(run()).resolves.not.toThrow()
+    expect(res._getStatusCode()).toBe(503)
+    expect(res._getHeaders()['retry-after']).toBe('30')
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
   it('refuses the key path on a network that is not allowlisted', async () => {
     process.env.FAUCET_API_KEY_NETWORKS = 'some-other-net'
     const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })

--- a/apps/web/tests/faucet.test.ts
+++ b/apps/web/tests/faucet.test.ts
@@ -1,0 +1,252 @@
+import { createMocks } from 'node-mocks-http'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthLevel, RequestStatus } from 'types'
+import { AdmissionChannel } from 'utils/metrics'
+
+const captchaVerify = vi.hoisted(() => vi.fn())
+const sendRequest = vi.hoisted(() => vi.fn())
+const getServerSession = vi.hoisted(() => vi.fn())
+const verifyKey = vi.hoisted(() => vi.fn())
+
+vi.mock('utils/captcha-verify', () => ({ captchaVerify }))
+vi.mock('utils/firebase.serverside', () => ({ sendRequest }))
+vi.mock('next-auth/next', () => ({ getServerSession }))
+vi.mock('utils/api-key', () => ({ verifyKey }))
+vi.mock('@vercel/functions', () => ({ ipAddress: () => '203.0.113.7' }))
+
+import handler from '../pages/api/faucet'
+
+const VALID = '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF'
+const KEY = `cfk_stg_0123456789ab_${'a'.repeat(43)}`
+
+function call(
+  body: Record<string, unknown> | undefined,
+  {
+    method = 'POST',
+    authorization,
+  }: {
+    method?: string
+    authorization?: string
+  } = {},
+) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: method as 'POST',
+    body,
+    headers: authorization ? { authorization } : {},
+  })
+  return { req, res, run: () => handler(req, res) }
+}
+
+const browserBody = {
+  captchaToken: 'token',
+  beneficiary: VALID,
+  network: 'celo-sepolia',
+}
+/** The key path sends no captchaToken. */
+const keyedBody = { beneficiary: VALID, network: 'celo-sepolia' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getServerSession.mockResolvedValue(null)
+  captchaVerify.mockResolvedValue({ success: true, score: 0.9 })
+  sendRequest.mockResolvedValue({ key: 'push-key-1' })
+  verifyKey.mockResolvedValue({
+    ok: true,
+    keyId: '0123456789ab',
+    ownerHash: '0xowner',
+  })
+  delete process.env.FAUCET_API_KEY_NETWORKS
+})
+
+describe('POST /api/faucet — browser path', () => {
+  // The contract the browser depends on: the exact body request-form.tsx sends
+  // must keep producing the same status and shape.
+  it('accepts the body the browser sends and returns Pending with a key', async () => {
+    const { res, run } = call(browserBody)
+    await run()
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData()).toEqual({
+      status: RequestStatus.Pending,
+      key: 'push-key-1',
+    })
+    expect(captchaVerify).toHaveBeenCalledTimes(1)
+    expect(captchaVerify).toHaveBeenCalledWith('token')
+    expect(verifyKey).not.toHaveBeenCalled()
+  })
+
+  it('passes AuthLevel.none and no userId when there is no session', async () => {
+    const { run } = call(browserBody)
+    await run()
+
+    expect(sendRequest).toHaveBeenCalledWith({
+      address: VALID,
+      skipStables: true,
+      network: 'celo-sepolia',
+      authLevel: AuthLevel.none,
+      channel: AdmissionChannel.browser,
+      ip: '203.0.113.7',
+      userId: undefined,
+    })
+  })
+
+  it('upgrades to authenticated and hashes the email when signed in', async () => {
+    getServerSession.mockResolvedValue({ user: { email: '0xdeadbeef' } })
+    const { run } = call(browserBody)
+    await run()
+
+    const [params] = sendRequest.mock.calls[0]
+    expect(params.authLevel).toBe(AuthLevel.authenticated)
+    expect(params.userId).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  it('returns 401 and never enqueues when the captcha fails', async () => {
+    captchaVerify.mockResolvedValue({
+      success: false,
+      'error-codes': ['invalid-input-response'],
+    })
+    const { res, run } = call(browserBody)
+    await run()
+
+    expect(res._getStatusCode()).toBe(401)
+    expect(res._getJSONData().message).toBe('invalid-input-response')
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 with the documented message when rate limited', async () => {
+    sendRequest.mockResolvedValue({
+      reason: 'rate_limited',
+      bucket: 'beneficiary',
+      count: 4,
+      limit: 4,
+    })
+    const { res, run } = call(browserBody)
+    await run()
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual({
+      status: RequestStatus.Failed,
+      message: 'Fauceting denied. Please check the faucet rules below.',
+    })
+  })
+
+  it('returns 404 when sendRequest throws', async () => {
+    sendRequest.mockRejectedValue(new Error('boom'))
+    const { res, run } = call(browserBody)
+    await run()
+
+    expect(res._getStatusCode()).toBe(404)
+    expect(res._getJSONData().message).toBe('Error while fauceting')
+  })
+})
+
+describe('POST /api/faucet — validation', () => {
+  it('rejects an unknown network before verifying anything', async () => {
+    const { res, run } = call({ ...browserBody, network: 'celo-mainnet' })
+    await run()
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(res._getJSONData().message).toBe('Invalid network: celo-mainnet')
+    expect(captchaVerify).not.toHaveBeenCalled()
+  })
+
+  it.each([['not-an-address'], [''], [undefined], [42]])(
+    'rejects beneficiary %s with 400 rather than a generic 404',
+    async (beneficiary) => {
+      const { res, run } = call({ ...browserBody, beneficiary })
+      await run()
+
+      expect(res._getStatusCode()).toBe(400)
+      expect(res._getJSONData().message).toBe('Invalid beneficiary address')
+      expect(sendRequest).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects non-POST with 405 and an Allow header', async () => {
+    const { res, run } = call(undefined, { method: 'GET' })
+    await run()
+
+    expect(res._getStatusCode()).toBe(405)
+    expect(res._getHeaders().allow).toBe('POST')
+    expect(captchaVerify).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/faucet — API key path', () => {
+  it('admits a valid key without any captcha and enqueues as authenticated', async () => {
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(captchaVerify).not.toHaveBeenCalled()
+    expect(getServerSession).not.toHaveBeenCalled()
+    expect(sendRequest).toHaveBeenCalledWith({
+      address: VALID,
+      skipStables: true,
+      network: 'celo-sepolia',
+      authLevel: AuthLevel.authenticated,
+      channel: AdmissionChannel.apiKey,
+      ip: '203.0.113.7',
+      userId: '0xowner',
+    })
+  })
+
+  // The property that keeps a key from being a quota upgrade: it is limited
+  // under the same identity as the browser session.
+  it('limits the key under its owner identity, not a fresh bucket', async () => {
+    const { run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(sendRequest.mock.calls[0][0].userId).toBe('0xowner')
+  })
+
+  it.each([
+    ['unknown' as const, 'Invalid or expired API key'],
+    ['malformed' as const, 'Invalid or expired API key'],
+  ])(
+    'returns 401 for a %s key and never falls back to captcha',
+    async (reason, message) => {
+      verifyKey.mockResolvedValue({ ok: false, reason })
+      const { res, run } = call(keyedBody, { authorization: 'Bearer nope' })
+      await run()
+
+      expect(res._getStatusCode()).toBe(401)
+      expect(res._getJSONData().message).toBe(message)
+      expect(captchaVerify).not.toHaveBeenCalled()
+      expect(sendRequest).not.toHaveBeenCalled()
+    },
+  )
+
+  it('returns 401 while the kill switch is set', async () => {
+    verifyKey.mockResolvedValue({ ok: false, reason: 'disabled' })
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getStatusCode()).toBe(401)
+    expect(res._getJSONData().message).toBe(
+      'Programmatic access is temporarily disabled',
+    )
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('ignores a non-bearer Authorization header and uses the browser path', async () => {
+    const { res, run } = call(browserBody, { authorization: 'Basic abc123' })
+    await run()
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(captchaVerify).toHaveBeenCalledTimes(1)
+    expect(verifyKey).not.toHaveBeenCalled()
+  })
+
+  it('refuses the key path on a network that is not allowlisted', async () => {
+    process.env.FAUCET_API_KEY_NETWORKS = 'some-other-net'
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(res._getJSONData().message).toContain('not enabled')
+    expect(verifyKey).not.toHaveBeenCalled()
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/faucet.test.ts
+++ b/apps/web/tests/faucet.test.ts
@@ -10,7 +10,13 @@ const getServerSession = vi.hoisted(() => vi.fn())
 const verifyKey = vi.hoisted(() => vi.fn())
 
 vi.mock('utils/captcha-verify', () => ({ captchaVerify }))
-vi.mock('utils/firebase.serverside', () => ({ sendRequest }))
+// The double must expose the real module's rate-limit constants too: the
+// handler reads their periods to build Retry-After.
+vi.mock('utils/firebase.serverside', () => ({
+  sendRequest,
+  PROGRAMMATIC_BURST_LIMIT: { count: 20, timePeriodInSeconds: 600 },
+  PROGRAMMATIC_GLOBAL_LIMIT: { count: 200, timePeriodInSeconds: 86400 },
+}))
 vi.mock('next-auth/next', () => ({ getServerSession }))
 vi.mock('utils/api-key', () => ({ verifyKey }))
 vi.mock('@vercel/functions', () => ({ ipAddress: () => '203.0.113.7' }))
@@ -252,7 +258,24 @@ describe('POST /api/faucet — API key path', () => {
 
     expect(res._getStatusCode()).toBe(429)
     expect(res._getJSONData().error).toBe('faucet_limit_exceeded')
+    // The daily bucket tripped, so the daily period is the honest wait.
     expect(res._getHeaders()['retry-after']).toBe('86400')
+  })
+
+  // Regression: Retry-After was hardcoded to a day, so an agent that honoured
+  // it lost 24 hours to a window that clears in ten minutes.
+  it('sends the ten-minute period when the burst window is what tripped', async () => {
+    sendRequest.mockResolvedValue({
+      reason: 'rate_limited',
+      bucket: 'programmatic-burst',
+      count: 20,
+      limit: 20,
+    })
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getStatusCode()).toBe(429)
+    expect(res._getHeaders()['retry-after']).toBe('600')
   })
 
   it('keeps the browser 403 unchanged when the browser is limited', async () => {

--- a/apps/web/tests/faucet.test.ts
+++ b/apps/web/tests/faucet.test.ts
@@ -239,6 +239,55 @@ describe('POST /api/faucet — API key path', () => {
     expect(verifyKey).not.toHaveBeenCalled()
   })
 
+  // CDP returns 429 with a machine-readable code; the browser keeps its 403.
+  it('returns 429 with faucet_limit_exceeded when a keyed request is limited', async () => {
+    sendRequest.mockResolvedValue({
+      reason: 'rate_limited',
+      bucket: 'user',
+      count: 10,
+      limit: 10,
+    })
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getStatusCode()).toBe(429)
+    expect(res._getJSONData().error).toBe('faucet_limit_exceeded')
+    expect(res._getHeaders()['retry-after']).toBe('86400')
+  })
+
+  it('keeps the browser 403 unchanged when the browser is limited', async () => {
+    sendRequest.mockResolvedValue({
+      reason: 'rate_limited',
+      bucket: 'beneficiary',
+      count: 4,
+      limit: 4,
+    })
+    const { res, run } = call(browserBody)
+    await run()
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual({
+      status: RequestStatus.Failed,
+      message: 'Fauceting denied. Please check the faucet rules below.',
+    })
+  })
+
+  it('tags an invalid key with invalid_api_key', async () => {
+    verifyKey.mockResolvedValue({ ok: false, reason: 'unknown' })
+    const { res, run } = call(keyedBody, { authorization: 'Bearer nope' })
+    await run()
+
+    expect(res._getJSONData().error).toBe('invalid_api_key')
+  })
+
+  it('tags a disabled key with api_key_disabled', async () => {
+    verifyKey.mockResolvedValue({ ok: false, reason: 'disabled' })
+    const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })
+    await run()
+
+    expect(res._getJSONData().error).toBe('api_key_disabled')
+  })
+
   it('refuses the key path on a network that is not allowlisted', async () => {
     process.env.FAUCET_API_KEY_NETWORKS = 'some-other-net'
     const { res, run } = call(keyedBody, { authorization: `Bearer ${KEY}` })

--- a/apps/web/tests/mint-race.test.ts
+++ b/apps/web/tests/mint-race.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MAX_KEYS_PER_OWNER } from 'types'
+
+/** Fake that yields at every await, like a real Redis round trip does. */
+class YieldingRedis {
+  hashes = new Map<string, Map<string, string>>()
+  sets = new Map<string, Set<string>>()
+  strings = new Map<string, string>()
+
+  private async tick() {
+    await new Promise((r) => setImmediate(r))
+  }
+  private hash(k: string) {
+    if (!this.hashes.has(k)) this.hashes.set(k, new Map())
+    return this.hashes.get(k)!
+  }
+  async hset(k: string, v: Record<string, unknown>) {
+    await this.tick()
+    const h = this.hash(k)
+    for (const [a, b] of Object.entries(v)) h.set(a, String(b))
+  }
+  async hgetall(k: string) {
+    await this.tick()
+    const h = this.hashes.get(k)
+    return h && h.size ? Object.fromEntries(h) : null
+  }
+  async hget(k: string, f: string) {
+    await this.tick()
+    return this.hashes.get(k)?.get(f) ?? null
+  }
+  async hmget(k: string, ...f: string[]) {
+    await this.tick()
+    const h = this.hashes.get(k)
+    if (!h) return null
+    return Object.fromEntries(
+      f.filter((x) => h.has(x)).map((x) => [x, h.get(x)!]),
+    )
+  }
+  async hdel(k: string, ...f: string[]) {
+    await this.tick()
+    f.forEach((x) => this.hashes.get(k)?.delete(x))
+  }
+  async sadd(k: string, ...m: string[]) {
+    await this.tick()
+    if (!this.sets.has(k)) this.sets.set(k, new Set())
+    m.forEach((x) => this.sets.get(k)!.add(x))
+  }
+  async smembers(k: string) {
+    await this.tick()
+    return [...(this.sets.get(k) ?? [])]
+  }
+  async scard(k: string) {
+    await this.tick()
+    return this.sets.get(k)?.size ?? 0
+  }
+  async srem(k: string, ...m: string[]) {
+    await this.tick()
+    m.forEach((x) => this.sets.get(k)?.delete(x))
+  }
+  async get(k: string) {
+    await this.tick()
+    return this.strings.get(k) ?? null
+  }
+  async del(k: string) {
+    await this.tick()
+    this.hashes.delete(k)
+  }
+  async expire() {
+    await this.tick()
+  }
+  multi() {
+    const ops: Array<() => Promise<unknown>> = []
+    const chain: Record<string, unknown> = {
+      hset: (k: string, v: Record<string, unknown>) => (
+        ops.push(() => this.hset(k, v)), chain
+      ),
+      sadd: (k: string, ...m: string[]) => (
+        ops.push(() => this.sadd(k, ...m)), chain
+      ),
+      expire: () => (ops.push(async () => undefined), chain),
+      exec: async () => {
+        for (const op of ops) await op()
+      },
+    }
+    return chain
+  }
+}
+
+const redis = vi.hoisted(() => ({ current: null as unknown }))
+vi.mock('../utils/redis', () => ({ getRedis: () => redis.current }))
+
+import { listKeysForOwner, mintKey } from '../utils/api-key'
+
+let fake: YieldingRedis
+const OWNER = '0xrace-owner'
+
+async function race(n: number) {
+  fake = new YieldingRedis()
+  redis.current = fake
+  const results = await Promise.allSettled(
+    Array.from({ length: n }, (_, i) => mintKey(OWNER, `k${i}`)),
+  )
+  const ok = results.filter((r) => r.status === 'fulfilled').length
+  const errored = results.length - ok
+  const held = (await listKeysForOwner(OWNER)).length
+  console.info(
+    `    ${n} concurrent -> ${ok} ok, ${errored} errored, owner holds ${held}`,
+  )
+  return { ok, errored, held }
+}
+
+// Regression: the cap rollback used to test set cardinality, which is a
+// property of the set rather than of this key, so every racer revoked its own
+// key and the owner ended up holding none.
+//
+// The fake here yields at every await, which a real Redis round trip does.
+// A synchronous fake cannot interleave, so it cannot catch this class of bug.
+describe('concurrent mintKey', () => {
+  beforeEach(() => {
+    process.env.FAUCET_API_KEY_PEPPER = 'test-pepper'
+    delete process.env.VERCEL_ENV
+  })
+
+  it('control: at the cap, everyone succeeds', async () => {
+    const r = await race(MAX_KEYS_PER_OWNER)
+    expect(r.held).toBe(MAX_KEYS_PER_OWNER)
+  })
+
+  it('one over the cap: the excess minter withdraws, the rest keep their keys', async () => {
+    const r = await race(MAX_KEYS_PER_OWNER + 1)
+    expect(r.held).toBe(MAX_KEYS_PER_OWNER)
+    expect(r.ok).toBe(MAX_KEYS_PER_OWNER)
+    expect(r.errored).toBe(1)
+  })
+
+  it('two over the cap: only the excess withdraw', async () => {
+    const r = await race(MAX_KEYS_PER_OWNER + 2)
+    expect(r.held).toBe(MAX_KEYS_PER_OWNER)
+    expect(r.ok).toBe(MAX_KEYS_PER_OWNER)
+    expect(r.errored).toBe(2)
+  })
+})

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -45,6 +45,21 @@ export enum RequestedTokenSet {
   Celo = 'Celo',
 }
 
+/**
+ * API-key metadata. Lives here rather than in utils/api-key so the keys page
+ * can render it without pulling node:crypto into the client bundle.
+ */
+export interface ApiKeyRecord {
+  keyId: string
+  label: string
+  ownerHash: string
+  createdAt: number
+  expiresAt: number
+}
+
+export const MAX_KEYS_PER_OWNER = 2
+export const KEY_TTL_DAYS = 90
+
 export type FaucetAPIResponse =
   | {
       status: RequestStatus.Done | RequestStatus.Pending | RequestStatus.Pending

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -68,4 +68,10 @@ export type FaucetAPIResponse =
   | {
       status: RequestStatus.Failed
       message: string
+      /**
+       * Machine-readable code, set on the API-key path only so programmatic
+       * callers can branch without parsing prose. Mirrors the CDP faucet's
+       * `faucet_limit_exceeded`.
+       */
+      error?: 'faucet_limit_exceeded' | 'invalid_api_key' | 'api_key_disabled'
     }

--- a/apps/web/utils/api-key.test.ts
+++ b/apps/web/utils/api-key.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/** Minimal in-memory stand-in for the Upstash client. */
+class FakeRedis {
+  hashes = new Map<string, Map<string, string>>()
+  sets = new Map<string, Set<string>>()
+  strings = new Map<string, string>()
+
+  private hash(key: string) {
+    if (!this.hashes.has(key)) this.hashes.set(key, new Map())
+    return this.hashes.get(key)!
+  }
+
+  async hset(key: string, value: Record<string, unknown>) {
+    const h = this.hash(key)
+    for (const [k, v] of Object.entries(value)) h.set(k, String(v))
+  }
+  async hgetall(key: string) {
+    const h = this.hashes.get(key)
+    return h && h.size ? Object.fromEntries(h) : null
+  }
+  async hget(key: string, field: string) {
+    return this.hashes.get(key)?.get(field) ?? null
+  }
+  async hmget(key: string, ...fields: string[]) {
+    const h = this.hashes.get(key)
+    if (!h) return null
+    return Object.fromEntries(
+      fields.filter((f) => h.has(f)).map((f) => [f, h.get(f)!]),
+    )
+  }
+  async hdel(key: string, ...fields: string[]) {
+    const h = this.hashes.get(key)
+    fields.forEach((f) => h?.delete(f))
+  }
+  async sadd(key: string, ...members: string[]) {
+    if (!this.sets.has(key)) this.sets.set(key, new Set())
+    members.forEach((m) => this.sets.get(key)!.add(m))
+  }
+  async smembers(key: string) {
+    return [...(this.sets.get(key) ?? [])]
+  }
+  async srem(key: string, ...members: string[]) {
+    members.forEach((m) => this.sets.get(key)?.delete(m))
+  }
+  async get(key: string) {
+    return this.strings.get(key) ?? null
+  }
+  async set(key: string, value: string) {
+    this.strings.set(key, value)
+  }
+  async del(key: string) {
+    this.hashes.delete(key)
+    this.strings.delete(key)
+  }
+  async expire() {}
+
+  multi() {
+    const ops: Array<() => Promise<unknown>> = []
+    const chain = {
+      hset: (k: string, v: Record<string, unknown>) => (
+        ops.push(() => this.hset(k, v)), chain
+      ),
+      sadd: (k: string, ...m: string[]) => (
+        ops.push(() => this.sadd(k, ...m)), chain
+      ),
+      expire: () => (ops.push(async () => {}), chain),
+      exec: async () => {
+        for (const op of ops) await op()
+      },
+    }
+    return chain
+  }
+}
+
+const redis = vi.hoisted(() => ({ current: null as unknown }))
+vi.mock('./redis', () => ({ getRedis: () => redis.current }))
+
+import { MAX_KEYS_PER_OWNER } from 'types'
+import {
+  listKeysForOwner,
+  mintKey,
+  parseKey,
+  revokeKey,
+  verifyKey,
+} from './api-key'
+
+const OWNER = '0xowner-hash'
+const OTHER = '0xsomeone-else'
+
+let fake: FakeRedis
+
+describe('api keys', () => {
+  beforeEach(() => {
+    fake = new FakeRedis()
+    redis.current = fake
+    process.env.FAUCET_API_KEY_PEPPER = 'test-pepper'
+    delete process.env.VERCEL_ENV
+    vi.useRealTimers()
+  })
+
+  it('mints a key in the documented format and verifies it', async () => {
+    const { key, record } = await mintKey(OWNER, 'my agent')
+
+    expect(key).toMatch(/^cfk_stg_[0-9a-f]{12}_[A-Za-z0-9_-]{43}$/)
+    expect(record.ownerHash).toBe(OWNER)
+    await expect(verifyKey(key)).resolves.toEqual({
+      ok: true,
+      keyId: record.keyId,
+      ownerHash: OWNER,
+    })
+  })
+
+  it('never stores the raw secret', async () => {
+    const { key } = await mintKey(OWNER, 'my agent')
+    const stored = JSON.stringify([...fake.hashes].map(([k, v]) => [k, [...v]]))
+
+    expect(stored).not.toContain(key)
+    expect(stored).not.toContain(key.split('_')[3])
+  })
+
+  it.each([
+    ['garbage'],
+    ['cfk_stg_short_x'],
+    ['cfk_xyz_0123456789ab_' + 'a'.repeat(43)],
+    ['nope_stg_0123456789ab_' + 'a'.repeat(43)],
+  ])('rejects malformed key %s', async (bad) => {
+    expect(parseKey(bad)).toBeUndefined()
+    await expect(verifyKey(bad)).resolves.toMatchObject({ ok: false })
+  })
+
+  // base64url secrets contain '_', so naive splitting on '_' breaks parsing.
+  it('parses a key whose secret contains underscores and dashes', () => {
+    const secret = `_-${'a'.repeat(41)}`
+    const parsed = parseKey(`cfk_stg_0123456789ab_${secret}`)
+
+    expect(parsed).toEqual({ keyId: '0123456789ab', tag: 'stg' })
+  })
+
+  it('verifies every minted key regardless of the secret drawn', async () => {
+    for (let i = 0; i < 200; i++) {
+      fake = new FakeRedis()
+      redis.current = fake
+      const { key } = await mintKey(OWNER, 'fuzz')
+      expect(await verifyKey(key)).toMatchObject({ ok: true })
+    }
+  })
+
+  it('rejects a well-formed key that was never issued', async () => {
+    const unissued = `cfk_stg_0123456789ab_${'a'.repeat(43)}`
+    await expect(verifyKey(unissued)).resolves.toEqual({
+      ok: false,
+      reason: 'unknown',
+    })
+  })
+
+  // A staging key must not authenticate against production.
+  it('rejects a key minted for a different environment', async () => {
+    const { key } = await mintKey(OWNER, 'staging key')
+    process.env.VERCEL_ENV = 'production'
+
+    await expect(verifyKey(key)).resolves.toEqual({
+      ok: false,
+      reason: 'malformed',
+    })
+  })
+
+  it('rejects every key while the kill switch is set', async () => {
+    const { key } = await mintKey(OWNER, 'my agent')
+    await fake.set('api-keys:disabled', '1')
+
+    await expect(verifyKey(key)).resolves.toEqual({
+      ok: false,
+      reason: 'disabled',
+    })
+  })
+
+  it('rejects an expired key and drops it from the listing', async () => {
+    const { key, record } = await mintKey(OWNER, 'my agent')
+    const stored = [...fake.hashes.keys()].find(
+      (k) => k.startsWith('api-keys:') && !k.endsWith(':index'),
+    )!
+    fake.hashes.get(stored)!.set('expiresAt', String(Date.now() - 1))
+
+    await expect(verifyKey(key)).resolves.toEqual({
+      ok: false,
+      reason: 'unknown',
+    })
+    await expect(listKeysForOwner(OWNER)).resolves.toEqual([])
+    expect(await fake.hget('api-keys:index', record.keyId)).toBeNull()
+  })
+
+  it('lists only the owner’s own keys', async () => {
+    await mintKey(OWNER, 'mine')
+    await mintKey(OTHER, 'theirs')
+
+    const mine = await listKeysForOwner(OWNER)
+    expect(mine).toHaveLength(1)
+    expect(mine[0].label).toBe('mine')
+  })
+
+  it(`caps an owner at ${MAX_KEYS_PER_OWNER} active keys`, async () => {
+    for (let i = 0; i < MAX_KEYS_PER_OWNER; i++) {
+      await mintKey(OWNER, `key ${i}`)
+    }
+    await expect(mintKey(OWNER, 'one too many')).rejects.toThrow(/already have/)
+  })
+
+  it('revokes a key so it stops verifying immediately', async () => {
+    const { key, record } = await mintKey(OWNER, 'my agent')
+
+    await expect(revokeKey(record.keyId, OWNER)).resolves.toBe(true)
+    await expect(verifyKey(key)).resolves.toEqual({
+      ok: false,
+      reason: 'unknown',
+    })
+    await expect(listKeysForOwner(OWNER)).resolves.toEqual([])
+  })
+
+  it('refuses to revoke a key belonging to another owner', async () => {
+    const { key, record } = await mintKey(OWNER, 'my agent')
+
+    await expect(revokeKey(record.keyId, OTHER)).resolves.toBe(false)
+    await expect(verifyKey(key)).resolves.toMatchObject({ ok: true })
+  })
+
+  it('frees a slot after a revoke', async () => {
+    const first = await mintKey(OWNER, 'a')
+    await mintKey(OWNER, 'b')
+    await revokeKey(first.record.keyId, OWNER)
+
+    await expect(mintKey(OWNER, 'c')).resolves.toBeTruthy()
+  })
+
+  it('throws when the pepper is not configured', async () => {
+    delete process.env.FAUCET_API_KEY_PEPPER
+    await expect(mintKey(OWNER, 'x')).rejects.toThrow(/FAUCET_API_KEY_PEPPER/)
+  })
+})

--- a/apps/web/utils/api-key.test.ts
+++ b/apps/web/utils/api-key.test.ts
@@ -40,6 +40,9 @@ class FakeRedis {
   async smembers(key: string) {
     return [...(this.sets.get(key) ?? [])]
   }
+  async scard(key: string) {
+    return this.sets.get(key)?.size ?? 0
+  }
   async srem(key: string, ...members: string[]) {
     members.forEach((m) => this.sets.get(key)?.delete(m))
   }
@@ -204,6 +207,20 @@ describe('api keys', () => {
       await mintKey(OWNER, `key ${i}`)
     }
     await expect(mintKey(OWNER, 'one too many')).rejects.toThrow(/already have/)
+  })
+
+  // Regression: the cap was check-then-act, so concurrent mints could both
+  // pass it and leave the owner over the limit.
+  it('holds the cap when mints race', async () => {
+    const results = await Promise.allSettled([
+      mintKey(OWNER, 'race a'),
+      mintKey(OWNER, 'race b'),
+      mintKey(OWNER, 'race c'),
+    ])
+
+    const minted = results.filter((r) => r.status === 'fulfilled').length
+    expect(minted).toBeLessThanOrEqual(MAX_KEYS_PER_OWNER)
+    await expect(listKeysForOwner(OWNER)).resolves.toHaveLength(minted)
   })
 
   it('revokes a key so it stops verifying immediately', async () => {

--- a/apps/web/utils/api-key.test.ts
+++ b/apps/web/utils/api-key.test.ts
@@ -119,7 +119,10 @@ describe('api keys', () => {
     const stored = JSON.stringify([...fake.hashes].map(([k, v]) => [k, [...v]]))
 
     expect(stored).not.toContain(key)
-    expect(stored).not.toContain(key.split('_')[3])
+    // Rejoined, not split('_')[3]: a base64url secret may contain '_', so
+    // indexing yields a fragment 48% of the time and '' when the secret
+    // starts with '_', which makes .not.toContain always fail.
+    expect(stored).not.toContain(key.split('_').slice(3).join('_'))
   })
 
   it.each([
@@ -219,6 +222,9 @@ describe('api keys', () => {
     ])
 
     const minted = results.filter((r) => r.status === 'fulfilled').length
+    // Greater than zero matters as much as the cap: a rollback that fires on
+    // every racer would leave the owner with nothing and still be <= the cap.
+    expect(minted).toBeGreaterThan(0)
     expect(minted).toBeLessThanOrEqual(MAX_KEYS_PER_OWNER)
     await expect(listKeysForOwner(OWNER)).resolves.toHaveLength(minted)
   })

--- a/apps/web/utils/api-key.ts
+++ b/apps/web/utils/api-key.ts
@@ -111,6 +111,17 @@ export async function mintKey(
   tx.expire(ownerKey(ownerHash), KEY_TTL_SECONDS)
   await tx.exec()
 
+  // The cap check above is check-then-act, so two concurrent mints can both
+  // pass it. Re-read the authoritative count and roll this key back if it
+  // put the owner over. Extra keys grant no extra quota, but the cap should
+  // still hold.
+  if ((await redis.scard(ownerKey(ownerHash))) > MAX_KEYS_PER_OWNER) {
+    await revokeKey(keyId, ownerHash)
+    throw new Error(
+      `You already have ${MAX_KEYS_PER_OWNER} active keys. Revoke one first.`,
+    )
+  }
+
   return { key, record }
 }
 

--- a/apps/web/utils/api-key.ts
+++ b/apps/web/utils/api-key.ts
@@ -112,10 +112,14 @@ export async function mintKey(
   await tx.exec()
 
   // The cap check above is check-then-act, so two concurrent mints can both
-  // pass it. Re-read the authoritative count and roll this key back if it
-  // put the owner over. Extra keys grant no extra quota, but the cap should
-  // still hold.
-  if ((await redis.scard(ownerKey(ownerHash))) > MAX_KEYS_PER_OWNER) {
+  // pass it. Re-read the membership and withdraw only the excess minters.
+  //
+  // Testing cardinality instead would be a property of the set rather than of
+  // this key, so every racer would revoke its own key and the owner would end
+  // up holding none. Sorting gives all racers the same total order, so the
+  // same keys survive whichever order they observe.
+  const members = (await redis.smembers(ownerKey(ownerHash))).sort()
+  if (members.indexOf(keyId) >= MAX_KEYS_PER_OWNER) {
     await revokeKey(keyId, ownerHash)
     throw new Error(
       `You already have ${MAX_KEYS_PER_OWNER} active keys. Revoke one first.`,

--- a/apps/web/utils/api-key.ts
+++ b/apps/web/utils/api-key.ts
@@ -1,0 +1,220 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { ApiKeyRecord, KEY_TTL_DAYS, MAX_KEYS_PER_OWNER } from 'types'
+import { getRedis } from './redis'
+
+/**
+ * Self-serve API keys for programmatic faucet access.
+ *
+ * A key is a second way to present a GitHub identity the faucet already
+ * understands, not a new trust tier: keyed requests share the owner's existing
+ * per-identity rate-limit bucket, so minting a key buys captcha bypass and
+ * never extra funds.
+ */
+
+const KEY_PREFIX = 'cfk'
+const SECRET_BYTES = 32
+const KEY_ID_BYTES = 6
+export const KEY_TTL_SECONDS = KEY_TTL_DAYS * 24 * 60 * 60
+
+const NAMESPACE = 'api-keys'
+const INDEX_KEY = `${NAMESPACE}:index`
+const DISABLED_KEY = `${NAMESPACE}:disabled`
+
+export type VerifyResult =
+  | { ok: true; keyId: string; ownerHash: string }
+  | { ok: false; reason: 'malformed' | 'unknown' | 'disabled' }
+
+/**
+ * `prd` keys must not work against staging and vice versa, which is
+ * impossible to retrofit once keys are in the wild.
+ */
+export function environmentTag(): string {
+  return process.env.VERCEL_ENV === 'production' ? 'prd' : 'stg'
+}
+
+function pepper(): string {
+  const value = process.env.FAUCET_API_KEY_PEPPER
+  if (!value) {
+    throw new Error('Missing in env: FAUCET_API_KEY_PEPPER')
+  }
+  return value
+}
+
+/**
+ * HMAC-SHA256, deliberately not bcrypt/argon2: the secret is 256 bits of
+ * CSPRNG output, so there is no dictionary to defend against and a slow KDF
+ * would only add latency to every faucet request. The pepper means a dump of
+ * the key store alone cannot be used to verify keys offline.
+ */
+function hashKey(presented: string): string {
+  return createHmac('sha256', pepper()).update(presented).digest('hex')
+}
+
+function recordKey(hash: string): string {
+  return `${NAMESPACE}:${hash}`
+}
+
+function ownerKey(ownerHash: string): string {
+  return `${NAMESPACE}:owner:${ownerHash}`
+}
+
+// Anchored rather than split on '_', because the base64url secret may itself
+// contain underscores. Every segment has a fixed length, so the match is
+// unambiguous.
+const KEY_PATTERN = new RegExp(
+  `^${KEY_PREFIX}_(prd|stg)_([0-9a-f]{${KEY_ID_BYTES * 2}})_[A-Za-z0-9_-]{43}$`,
+)
+
+/** Shape check only; says nothing about whether the key exists. */
+export function parseKey(
+  presented: string,
+): { keyId: string; tag: string } | undefined {
+  const match = KEY_PATTERN.exec(presented)
+  if (!match) return undefined
+  return { keyId: match[2], tag: match[1] }
+}
+
+export async function mintKey(
+  ownerHash: string,
+  label: string,
+): Promise<{ key: string; record: ApiKeyRecord }> {
+  const redis = getRedis()
+
+  const existing = await listKeysForOwner(ownerHash)
+  if (existing.length >= MAX_KEYS_PER_OWNER) {
+    throw new Error(
+      `You already have ${MAX_KEYS_PER_OWNER} active keys. Revoke one first.`,
+    )
+  }
+
+  const keyId = randomBytes(KEY_ID_BYTES).toString('hex')
+  const secret = randomBytes(SECRET_BYTES).toString('base64url')
+  const key = `${KEY_PREFIX}_${environmentTag()}_${keyId}_${secret}`
+
+  const now = Date.now()
+  const record: ApiKeyRecord = {
+    keyId,
+    label: label.slice(0, 60),
+    ownerHash,
+    createdAt: now,
+    expiresAt: now + KEY_TTL_SECONDS * 1000,
+  }
+
+  const hash = hashKey(key)
+  const tx = redis.multi()
+  tx.hset(recordKey(hash), record as unknown as Record<string, unknown>)
+  tx.expire(recordKey(hash), KEY_TTL_SECONDS)
+  // Without the index an operator who no longer holds the raw secret cannot
+  // compute the hash, and therefore cannot revoke the key.
+  tx.hset(INDEX_KEY, { [keyId]: hash })
+  tx.sadd(ownerKey(ownerHash), keyId)
+  tx.expire(ownerKey(ownerHash), KEY_TTL_SECONDS)
+  await tx.exec()
+
+  return { key, record }
+}
+
+export async function verifyKey(presented: string): Promise<VerifyResult> {
+  const parsed = parseKey(presented)
+  if (!parsed || parsed.tag !== environmentTag()) {
+    return { ok: false, reason: 'malformed' }
+  }
+
+  const redis = getRedis()
+  const hash = hashKey(presented)
+
+  // Fetched together so the kill switch costs no extra round trip.
+  const [disabled, record] = await Promise.all([
+    redis.get<string>(DISABLED_KEY),
+    redis.hgetall<Record<string, string>>(recordKey(hash)),
+  ])
+
+  if (disabled) {
+    return { ok: false, reason: 'disabled' }
+  }
+  if (!record || !record.keyId) {
+    return { ok: false, reason: 'unknown' }
+  }
+
+  // The keyId inside the presented token is untrusted; the stored record is
+  // authoritative. Compared defensively in case a record is ever written by
+  // something other than mintKey.
+  const presentedId = Buffer.from(parsed.keyId)
+  const storedId = Buffer.from(record.keyId)
+  if (
+    presentedId.length !== storedId.length ||
+    !timingSafeEqual(presentedId, storedId)
+  ) {
+    return { ok: false, reason: 'unknown' }
+  }
+
+  if (Number(record.expiresAt) <= Date.now()) {
+    return { ok: false, reason: 'unknown' }
+  }
+
+  return { ok: true, keyId: record.keyId, ownerHash: record.ownerHash }
+}
+
+export async function listKeysForOwner(
+  ownerHash: string,
+): Promise<ApiKeyRecord[]> {
+  const redis = getRedis()
+  const keyIds = await redis.smembers(ownerKey(ownerHash))
+  if (!keyIds.length) return []
+
+  const hashes = await redis.hmget<Record<string, string>>(INDEX_KEY, ...keyIds)
+  const records = await Promise.all(
+    keyIds.map(async (keyId) => {
+      const hash = hashes?.[keyId]
+      if (!hash) return undefined
+      return redis.hgetall<Record<string, string>>(recordKey(hash))
+    }),
+  )
+
+  const live: ApiKeyRecord[] = []
+  const stale: string[] = []
+  keyIds.forEach((keyId, i) => {
+    const record = records[i]
+    if (record?.keyId && Number(record.expiresAt) > Date.now()) {
+      live.push({
+        keyId: record.keyId,
+        label: record.label,
+        ownerHash: record.ownerHash,
+        createdAt: Number(record.createdAt),
+        expiresAt: Number(record.expiresAt),
+      })
+    } else {
+      // Records expire via their own TTL; the owner set has to be tidied here.
+      stale.push(keyId)
+    }
+  })
+
+  if (stale.length) {
+    await Promise.all([
+      redis.srem(ownerKey(ownerHash), ...stale),
+      redis.hdel(INDEX_KEY, ...stale),
+    ])
+  }
+
+  return live.sort((a, b) => b.createdAt - a.createdAt)
+}
+
+/** Returns false when the key does not exist or belongs to someone else. */
+export async function revokeKey(
+  keyId: string,
+  ownerHash: string,
+): Promise<boolean> {
+  const redis = getRedis()
+  const hash = await redis.hget<string>(INDEX_KEY, keyId)
+  if (!hash) return false
+
+  const record = await redis.hgetall<Record<string, string>>(recordKey(hash))
+  if (!record || record.ownerHash !== ownerHash) return false
+
+  await Promise.all([
+    redis.del(recordKey(hash)),
+    redis.hdel(INDEX_KEY, keyId),
+    redis.srem(ownerKey(ownerHash), keyId),
+  ])
+  return true
+}

--- a/apps/web/utils/captcha-verify.ts
+++ b/apps/web/utils/captcha-verify.ts
@@ -9,10 +9,13 @@ enum Errors {
   Timeout = 'timeout-or-duplicate',
 }
 
-interface RecaptchaResponse {
+export interface RecaptchaResponse {
   success: boolean
   challenge_ts: string // timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ)
   apk_package_name: string // the package name of the app where the reCAPTCHA was solved
+  score?: number // v3 only: 0.0 (likely a bot) to 1.0 (likely a human)
+  action?: string // v3 only: the action name passed to executeRecaptcha
+  hostname?: string
   'error-codes'?: Errors[] // optional
 }
 

--- a/apps/web/utils/firebase.serverside.test.ts
+++ b/apps/web/utils/firebase.serverside.test.ts
@@ -32,6 +32,7 @@ vi.mock('viem', async (importActual) => ({
 }))
 
 import {
+  PROGRAMMATIC_BURST_LIMIT,
   PROGRAMMATIC_GLOBAL_LIMIT,
   RATE_LIMITS,
   sendRequest,
@@ -184,6 +185,28 @@ describe('sendRequest', () => {
       await expect(sendRequest(keyed())).resolves.toMatchObject({
         reason: 'rate_limited',
         bucket: 'user',
+      })
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    // Regression: every keyed bucket was a 24h window, so a day's worth of
+    // requests could arrive at once and starve the payout pool.
+    it('is subject to a sub-daily concurrency window', async () => {
+      await sendRequest(keyed())
+
+      const ttls = hexpire.mock.calls.map(([, , ttl]) => Number(ttl))
+      expect(Math.min(...ttls)).toBeLessThan(24 * 60 * 60)
+      expect(writtenPaths()).toContain('api-key-counts:burst')
+    })
+
+    it('rate limits on the programmatic burst ceiling', async () => {
+      hlen.mockImplementation(async (key: string) =>
+        key === 'api-key-counts:burst' ? PROGRAMMATIC_BURST_LIMIT.count : 0,
+      )
+
+      await expect(sendRequest(keyed())).resolves.toMatchObject({
+        reason: 'rate_limited',
+        bucket: 'programmatic-burst',
       })
       expect(push).not.toHaveBeenCalled()
     })

--- a/apps/web/utils/firebase.serverside.test.ts
+++ b/apps/web/utils/firebase.serverside.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthLevel, RequestStatus } from 'types'
+import { AdmissionChannel } from './metrics'
+
+const push = vi.hoisted(() =>
+  vi.fn(async (_record: Record<string, unknown>) => ({ key: 'push-key-1' })),
+)
+const ref = vi.hoisted(() => vi.fn(() => ({ push })))
+const hlen = vi.hoisted(() => vi.fn(async (_path: string) => 0))
+const exec = vi.hoisted(() => vi.fn(async () => []))
+const hsetnx = vi.hoisted(() => vi.fn())
+const hexpire = vi.hoisted(() => vi.fn())
+const getBalance = vi.hoisted(() => vi.fn(async () => 0n))
+const readContract = vi.hoisted(() => vi.fn(async () => 0n))
+
+vi.mock('firebase/compat/app', () => ({
+  default: { apps: [{}], database: () => ({ ref }) },
+}))
+vi.mock('firebase/compat/auth', () => ({}))
+vi.mock('firebase/compat/database', () => ({}))
+
+vi.mock('./redis', () => ({
+  getRedis: () => ({
+    hlen,
+    multi: () => ({ hsetnx, expire: vi.fn(), hexpire, exec }),
+  }),
+}))
+
+vi.mock('viem', async (importActual) => ({
+  ...(await importActual<typeof import('viem')>()),
+  createPublicClient: () => ({ getBalance, readContract }),
+}))
+
+import {
+  PROGRAMMATIC_GLOBAL_LIMIT,
+  RATE_LIMITS,
+  sendRequest,
+} from './firebase.serverside'
+
+const ADDRESS = '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF'
+const WEI = 10n ** 18n
+
+function pushedRecord() {
+  return push.mock.calls[0][0]
+}
+
+/** Bucket paths touched by the write transaction. */
+function writtenPaths() {
+  return hsetnx.mock.calls.map(([path]) => String(path))
+}
+
+function base(overrides = {}) {
+  return {
+    address: ADDRESS,
+    skipStables: true,
+    network: 'celo-sepolia' as const,
+    authLevel: AuthLevel.none,
+    channel: AdmissionChannel.browser,
+    ...overrides,
+  }
+}
+
+describe('sendRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hlen.mockResolvedValue(0)
+    getBalance.mockResolvedValue(0n)
+    readContract.mockResolvedValue(0n)
+  })
+
+  it('enqueues a Pending Celo request and returns the push key', async () => {
+    const result = await sendRequest(base({ ip: '203.0.113.7' }))
+
+    expect(result).toEqual({ key: 'push-key-1' })
+    expect(ref).toHaveBeenCalledWith('celo-sepolia/requests')
+    expect(pushedRecord()).toMatchObject({
+      beneficiary: ADDRESS,
+      status: RequestStatus.Pending,
+      authLevel: AuthLevel.none,
+    })
+  })
+
+  // Regression: newRequest used to be built before the elevation ran, so the
+  // queued record kept authLevel 'none' and the payout stayed at 0.3 CELO.
+  it('records the elevated authLevel when the beneficiary holds mainnet ETH', async () => {
+    getBalance.mockResolvedValue(WEI / 100n) // exactly 0.01 ETH
+    await sendRequest(base())
+
+    expect(pushedRecord().authLevel).toBe(AuthLevel.authenticated)
+  })
+
+  it('records the elevated authLevel when the beneficiary has LockedCELO', async () => {
+    readContract.mockResolvedValue(100n * WEI)
+    await sendRequest(base())
+
+    expect(pushedRecord().authLevel).toBe(AuthLevel.authenticated)
+  })
+
+  it('leaves authLevel none when the address is below both thresholds', async () => {
+    getBalance.mockResolvedValue(WEI / 200n)
+    readContract.mockResolvedValue(99n * WEI)
+    await sendRequest(base())
+
+    expect(pushedRecord().authLevel).toBe(AuthLevel.none)
+  })
+
+  it('rate limits without enqueuing once the beneficiary is at its cap', async () => {
+    hlen.mockImplementation(async (key: string) =>
+      key.includes(ADDRESS) ? RATE_LIMITS[AuthLevel.none].count : 0,
+    )
+
+    const result = await sendRequest(base())
+
+    expect(result).toMatchObject({
+      reason: 'rate_limited',
+      bucket: 'beneficiary',
+      limit: RATE_LIMITS[AuthLevel.none].count,
+    })
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  // Regression: the user bucket TTL was hardcoded to the authenticated period.
+  it('expires the user bucket using the period for the request authLevel', async () => {
+    await sendRequest(base({ ip: '203.0.113.7', userId: 'user-hash' }))
+
+    const userCall = hexpire.mock.calls.find(([key]) =>
+      String(key).endsWith('user-hash'),
+    )
+    expect(userCall?.[2]).toBe(RATE_LIMITS[AuthLevel.none].timePeriodInSeconds)
+  })
+
+  describe('browser channel', () => {
+    it('counts against the shared global and per-IP buckets', async () => {
+      await sendRequest(base({ ip: '203.0.113.7' }))
+
+      expect(writtenPaths()).toEqual(
+        expect.arrayContaining([
+          'rate-limits:global',
+          'ip-counts:203.0.113.7',
+          `rate-limits:${ADDRESS}`,
+        ]),
+      )
+      expect(writtenPaths()).not.toContain('api-key-counts:global')
+    })
+  })
+
+  describe('api-key channel', () => {
+    const keyed = () =>
+      base({
+        channel: AdmissionChannel.apiKey,
+        authLevel: AuthLevel.authenticated,
+        userId: 'owner-hash',
+        ip: '203.0.113.7',
+      })
+
+    it('uses its own global ceiling and skips the IP bucket', async () => {
+      await sendRequest(keyed())
+      const paths = writtenPaths()
+
+      expect(paths).toContain('api-key-counts:global')
+      expect(paths).not.toContain('rate-limits:global')
+      expect(paths).not.toContain('ip-counts:203.0.113.7')
+    })
+
+    // Minting a key must not create a second quota.
+    it('still counts against the owner and beneficiary buckets', async () => {
+      await sendRequest(keyed())
+
+      expect(writtenPaths()).toEqual(
+        expect.arrayContaining([
+          'rate-limits:owner-hash',
+          `rate-limits:${ADDRESS}`,
+        ]),
+      )
+    })
+
+    it('rate limits when the owner identity is already at its cap', async () => {
+      hlen.mockImplementation(async (key: string) =>
+        key.endsWith('owner-hash')
+          ? RATE_LIMITS[AuthLevel.authenticated].count
+          : 0,
+      )
+
+      await expect(sendRequest(keyed())).resolves.toMatchObject({
+        reason: 'rate_limited',
+        bucket: 'user',
+      })
+      expect(push).not.toHaveBeenCalled()
+    })
+
+    it('rate limits on the programmatic global ceiling', async () => {
+      hlen.mockImplementation(async (key: string) =>
+        key === 'api-key-counts:global' ? PROGRAMMATIC_GLOBAL_LIMIT.count : 0,
+      )
+
+      await expect(sendRequest(keyed())).resolves.toMatchObject({
+        reason: 'rate_limited',
+        bucket: 'programmatic-global',
+      })
+    })
+
+    it('honours PROGRAMMATIC_GLOBAL_DAILY_LIMIT from the environment', async () => {
+      process.env.PROGRAMMATIC_GLOBAL_DAILY_LIMIT = '5'
+      hlen.mockImplementation(async (key: string) =>
+        key === 'api-key-counts:global' ? 5 : 0,
+      )
+
+      await expect(sendRequest(keyed())).resolves.toMatchObject({
+        reason: 'rate_limited',
+        bucket: 'programmatic-global',
+        limit: 5,
+      })
+      delete process.env.PROGRAMMATIC_GLOBAL_DAILY_LIMIT
+    })
+  })
+})

--- a/apps/web/utils/firebase.serverside.ts
+++ b/apps/web/utils/firebase.serverside.ts
@@ -1,5 +1,4 @@
 import { lockedGoldABI } from '@celo/abis'
-import { Redis } from '@upstash/redis'
 import firebase from 'firebase/compat/app'
 import 'firebase/compat/auth'
 import 'firebase/compat/database'
@@ -15,6 +14,8 @@ import {
 import { createPublicClient, fallback, getAddress, http } from 'viem'
 import { celo, mainnet } from 'viem/chains'
 import { config } from './firebase-config'
+import { AdmissionChannel } from './metrics'
+import { getRedis } from './redis'
 
 async function getFirebase() {
   if (!firebase.apps.length) {
@@ -66,92 +67,151 @@ export const RATE_LIMITS_PER_IP: RateLimit = {
   timePeriodInSeconds: 24 * HOURS,
 }
 
-export async function sendRequest(
-  address: Address,
-  skipStables: boolean,
-  network: Network,
-  authLevel: AuthLevel,
-  ip?: string,
-  userId?: string,
-): Promise<{ key?: string; reason?: 'rate_limited' }> {
+function envCount(name: string, fallback: number): number {
+  const parsed = Number(process.env[name])
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+/**
+ * Daily ceiling across every API key, kept separate from GLOBAL_RATE_LIMITS so
+ * programmatic traffic can never starve the browser path. This is the number
+ * that bounds a total key compromise.
+ */
+export const PROGRAMMATIC_GLOBAL_LIMIT: RateLimit = {
+  get count() {
+    return envCount('PROGRAMMATIC_GLOBAL_DAILY_LIMIT', 200)
+  },
+  timePeriodInSeconds: 24 * HOURS,
+}
+
+export type RateLimitBucket =
+  | 'global'
+  | 'beneficiary'
+  | 'ip'
+  | 'user'
+  | 'programmatic-global'
+
+interface Bucket {
+  name: RateLimitBucket
+  path: string
+  limit: RateLimit
+}
+
+export interface SendRequestParams {
+  address: Address
+  skipStables: boolean
+  network: Network
+  authLevel: AuthLevel
+  channel: AdmissionChannel
+  ip?: string
+  /** sha256 of the GitHub email. Shared by the browser and API-key paths. */
+  userId?: string
+}
+
+export interface SendRequestResult {
+  key?: string
+  reason?: 'rate_limited'
+  /** Which cap was hit, for logging. */
+  bucket?: RateLimitBucket
+  count?: number
+  limit?: number
+}
+
+export async function sendRequest({
+  address,
+  skipStables,
+  network,
+  authLevel,
+  channel,
+  ip,
+  userId,
+}: SendRequestParams): Promise<SendRequestResult> {
   // NOTE: make sure address is stable (no lowercase/not-prefixed BS)
   const beneficiary = getAddress(
     address.startsWith('0x') ? address : `0x${address}`,
   )
 
-  const newRequest: RequestRecord = {
-    beneficiary,
-    status: RequestStatus.Pending,
-    type: RequestType.Faucet,
-    tokens: skipStables ? RequestedTokenSet.Celo : RequestedTokenSet.All,
-    authLevel,
-  }
-
   try {
     if (await addressCanBeElevatedToTrusted(beneficiary)) {
       authLevel = AuthLevel.authenticated
     }
+
+    // Built after the elevation above: capturing authLevel any earlier records
+    // the pre-elevation value on the queued request, so a trusted address is
+    // paid faucetGoldAmount instead of authenticatedGoldAmount.
+    const newRequest: RequestRecord = {
+      beneficiary,
+      status: RequestStatus.Pending,
+      type: RequestType.Faucet,
+      tokens: skipStables ? RequestedTokenSet.Celo : RequestedTokenSet.All,
+      authLevel,
+    }
+
     const db = await getDB()
-    const redis = Redis.fromEnv()
+    const redis = getRedis()
     const namespace = 'rate-limits'
     const ipNamespace = 'ip-counts'
+    const programmatic = channel === AdmissionChannel.apiKey
 
-    const [
-      pendingRequestCountGlobal,
-      pendingRequestCountForBeneficiary,
-      pendingRequestCountForUser,
-      pendingRequestCountForIp,
-    ] = await Promise.all([
-      redis.hlen(`${namespace}:global`),
-      redis.hlen(`${namespace}:${beneficiary}`),
-      userId ? redis.hlen(`${namespace}:${userId}`) : 0,
-      redis.hlen(`${ipNamespace}:${ip}`),
-    ])
-
-    if (pendingRequestCountGlobal >= GLOBAL_RATE_LIMITS[authLevel].count) {
-      return { reason: 'rate_limited' }
+    const buckets: Bucket[] = []
+    if (programmatic) {
+      buckets.push({
+        name: 'programmatic-global',
+        path: `api-key-counts:global`,
+        limit: PROGRAMMATIC_GLOBAL_LIMIT,
+      })
+    } else {
+      buckets.push({
+        name: 'global',
+        path: `${namespace}:global`,
+        limit: GLOBAL_RATE_LIMITS[authLevel],
+      })
+      // Skipped for keyed requests: CI runners and agent hosts share egress
+      // IPs, and the key owner is already the identity being limited.
+      buckets.push({
+        name: 'ip',
+        path: `${ipNamespace}:${ip}`,
+        limit: RATE_LIMITS_PER_IP,
+      })
     }
-
-    if (pendingRequestCountForIp >= RATE_LIMITS_PER_IP.count) {
-      return { reason: 'rate_limited' }
+    if (userId) {
+      buckets.push({
+        name: 'user',
+        path: `${namespace}:${userId}`,
+        limit: RATE_LIMITS[authLevel],
+      })
     }
+    buckets.push({
+      name: 'beneficiary',
+      path: `${namespace}:${beneficiary}`,
+      limit: RATE_LIMITS[authLevel],
+    })
 
-    if (userId && pendingRequestCountForUser >= RATE_LIMITS[authLevel].count) {
-      return { reason: 'rate_limited' }
-    }
+    const counts = await Promise.all(
+      buckets.map((bucket) => redis.hlen(bucket.path)),
+    )
 
-    if (pendingRequestCountForBeneficiary >= RATE_LIMITS[authLevel].count) {
-      return { reason: 'rate_limited' }
+    for (const [i, bucket] of buckets.entries()) {
+      if (counts[i] >= bucket.limit.count) {
+        return {
+          reason: 'rate_limited',
+          bucket: bucket.name,
+          count: counts[i],
+          limit: bucket.limit.count,
+        }
+      }
     }
 
     const ref: firebase.database.Reference = await db
       .ref(`${network}/requests`)
       .push(newRequest)
 
-    const params = {
-      // INCREASE GLOBAL COUNT
-      [`${namespace}:global`]:
-        GLOBAL_RATE_LIMITS[authLevel].timePeriodInSeconds,
-
-      // INCREASE COUNT FOR BENEFICIARY
-      [`${namespace}:${beneficiary}`]:
-        RATE_LIMITS[authLevel].timePeriodInSeconds,
-
-      // INCREASE COUNT FOR USER IDENTIFIER IF AUTHENTICATED
-      ...(userId != null && {
-        [`${namespace}:${userId}`]:
-          RATE_LIMITS.authenticated.timePeriodInSeconds,
-      }),
-      // INCREASE COUNT FOR IP
-      [`${ipNamespace}:${ip}`]: RATE_LIMITS_PER_IP.timePeriodInSeconds,
-    }
-
     /// BEGIN TRANSACTION
     const tx = redis.multi()
-    for (const [path, ttl] of Object.entries(params)) {
-      tx.hsetnx(path, ref.key!, 1)
-      tx.expire(path, ttl)
-      tx.hexpire(path, ref.key!, ttl)
+    for (const bucket of buckets) {
+      tx.hsetnx(bucket.path, ref.key!, 1)
+      tx.expire(bucket.path, bucket.limit.timePeriodInSeconds)
+      tx.hexpire(bucket.path, ref.key!, bucket.limit.timePeriodInSeconds)
     }
     await tx.exec()
     /// END TRANSACTION
@@ -161,6 +221,18 @@ export async function sendRequest(
     console.error(`Error while sendRequest: ${e}`)
     throw e
   }
+}
+
+/** Legacy field name written before the goldTxHash fix. */
+type StoredRequestRecord = RequestRecord & { celoTxhash?: string }
+
+export async function getRequestRecord(
+  key: string,
+  network: Network,
+): Promise<StoredRequestRecord | undefined> {
+  const db = await getDB()
+  const snap = await db.ref(`${network}/requests/${key}`).once('value')
+  return snap.val() ?? undefined
 }
 
 const ethPublicClient = createPublicClient({

--- a/apps/web/utils/firebase.serverside.ts
+++ b/apps/web/utils/firebase.serverside.ts
@@ -84,12 +84,29 @@ export const PROGRAMMATIC_GLOBAL_LIMIT: RateLimit = {
   timePeriodInSeconds: 24 * HOURS,
 }
 
+/**
+ * Short concurrency window for keyed traffic.
+ *
+ * The daily ceiling bounds total spend but says nothing about arrival rate.
+ * Without this, a day's worth of keyed requests can land at once, lock every
+ * account in the payout pool and starve the browser path with
+ * NoFreeAccountErr. It mirrors GLOBAL_RATE_LIMITS, which is the equivalent
+ * concurrency guard on the browser path.
+ */
+export const PROGRAMMATIC_BURST_LIMIT: RateLimit = {
+  get count() {
+    return envCount('PROGRAMMATIC_BURST_LIMIT', 20)
+  },
+  timePeriodInSeconds: 10 * MINUTES,
+}
+
 export type RateLimitBucket =
   | 'global'
   | 'beneficiary'
   | 'ip'
   | 'user'
   | 'programmatic-global'
+  | 'programmatic-burst'
 
 interface Bucket {
   name: RateLimitBucket
@@ -155,6 +172,11 @@ export async function sendRequest({
 
     const buckets: Bucket[] = []
     if (programmatic) {
+      buckets.push({
+        name: 'programmatic-burst',
+        path: `api-key-counts:burst`,
+        limit: PROGRAMMATIC_BURST_LIMIT,
+      })
       buckets.push({
         name: 'programmatic-global',
         path: `api-key-counts:global`,

--- a/apps/web/utils/metrics.test.ts
+++ b/apps/web/utils/metrics.test.ts
@@ -1,0 +1,47 @@
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { hashIp } from './metrics'
+
+const IP = '203.0.113.47'
+
+describe('hashIp', () => {
+  beforeEach(() => {
+    process.env.FAUCET_API_KEY_PEPPER = 'test-pepper'
+  })
+  afterEach(() => {
+    process.env.FAUCET_API_KEY_PEPPER = 'test-pepper'
+  })
+
+  it('is stable for the same address', () => {
+    expect(hashIp(IP)).toBe(hashIp(IP))
+  })
+
+  it('distinguishes different addresses', () => {
+    expect(hashIp(IP)).not.toBe(hashIp('203.0.113.48'))
+  })
+
+  it('returns undefined for a missing address', () => {
+    expect(hashIp(undefined)).toBeUndefined()
+  })
+
+  // Regression: an unsalted digest over the 2^32 IPv4 space is reversible by
+  // brute force in well under an hour on a single core, so the output must not
+  // be derivable from the address alone.
+  it('is not a bare digest of the address', () => {
+    const bare = createHash('sha256').update(IP).digest('hex')
+    expect(hashIp(IP)).not.toBe(bare.slice(0, 16))
+    expect(bare).not.toContain(hashIp(IP) as string)
+  })
+
+  it('changes with the pepper, so the log is not reversible without it', () => {
+    const withA = hashIp(IP)
+    process.env.FAUCET_API_KEY_PEPPER = 'a-different-pepper'
+    expect(hashIp(IP)).not.toBe(withA)
+  })
+
+  // Better to drop the field than to log something that looks anonymised.
+  it('omits the value entirely when no pepper is configured', () => {
+    delete process.env.FAUCET_API_KEY_PEPPER
+    expect(hashIp(IP)).toBeUndefined()
+  })
+})

--- a/apps/web/utils/metrics.ts
+++ b/apps/web/utils/metrics.ts
@@ -1,0 +1,83 @@
+import { sha256, toHex } from 'viem'
+
+/**
+ * Structured logging for the web side of the faucet.
+ *
+ * Vercel Runtime Logs capture stdout/stderr, so a log drain can aggregate on
+ * the stable `event` key. The shape mirrors `apps/firebase/src/metrics.ts` so
+ * both halves of the faucet emit the same `celo/faucet/*` namespace.
+ *
+ * `@google-cloud/logging` is deliberately not used here: it is a heavy
+ * dependency with its own credentials and would add cold-start cost to every
+ * serverless invocation.
+ */
+
+export enum AdmissionChannel {
+  browser = 'browser',
+  apiKey = 'api-key',
+}
+
+export enum AdmissionOutcome {
+  admitted = 'admitted',
+  captchaFailed = 'captcha_failed',
+  invalidKey = 'invalid_key',
+  keyDisabled = 'key_disabled',
+  badRequest = 'bad_request',
+}
+
+/** Never log a raw IP; hash it so counts stay comparable without the address. */
+export function hashIp(ip: string | undefined): string | undefined {
+  return ip ? sha256(toHex(ip)).slice(0, 18) : undefined
+}
+
+function emit(level: 'info' | 'warn', entry: Record<string, unknown>) {
+  const line = JSON.stringify(entry)
+  if (level === 'warn') {
+    console.warn(line)
+  } else {
+    console.info(line)
+  }
+}
+
+export function logAdmission(data: {
+  channel: AdmissionChannel
+  outcome: AdmissionOutcome
+  network?: string
+  authLevel?: string
+  /** Public key identifier. Never the raw key or its hash. */
+  keyId?: string
+  ipHash?: string
+  /** reCAPTCHA v3 score, otherwise discarded by `captchaVerify`. */
+  captchaScore?: number
+  errorCodes?: string[]
+}) {
+  emit(data.outcome === AdmissionOutcome.admitted ? 'info' : 'warn', {
+    event: 'celo/faucet/admission',
+    ...data,
+  })
+}
+
+/**
+ * A 403 currently logs nothing at all, which makes a drain indistinguishable
+ * from a misconfigured cap.
+ */
+export function logRateLimited(data: {
+  channel: AdmissionChannel
+  bucket: string
+  count: number
+  limit: number
+  network: string
+  keyId?: string
+}) {
+  emit('warn', { event: 'celo/faucet/rate_limited', ...data })
+}
+
+export function logEnqueued(data: {
+  channel: AdmissionChannel
+  key: string
+  authLevel: string
+  network: string
+  keyId?: string
+}) {
+  emit('info', { event: 'celo/faucet/enqueued', ...data })
+}

--- a/apps/web/utils/metrics.ts
+++ b/apps/web/utils/metrics.ts
@@ -1,4 +1,4 @@
-import { sha256, toHex } from 'viem'
+import { createHmac } from 'node:crypto'
 
 /**
  * Structured logging for the web side of the faucet.
@@ -25,9 +25,25 @@ export enum AdmissionOutcome {
   badRequest = 'bad_request',
 }
 
-/** Never log a raw IP; hash it so counts stay comparable without the address. */
+/**
+ * Pseudonymise an IP for logging.
+ *
+ * A bare digest is not enough here: IPv4 is only 2^32 inputs, so an unsalted
+ * hash is a brute force away from the address (~40 minutes on one core), and
+ * a rainbow table resolves every log line ever emitted. Keyed with the
+ * server-side pepper the log is only reversible by someone who already holds
+ * the secret, which is the same reasoning `api-key.ts` applies to key storage.
+ *
+ * With no pepper configured the field is omitted rather than logged
+ * reversibly, so the logs never contain something that merely looks
+ * anonymised.
+ */
 export function hashIp(ip: string | undefined): string | undefined {
-  return ip ? sha256(toHex(ip)).slice(0, 18) : undefined
+  const pepper = process.env.FAUCET_API_KEY_PEPPER
+  if (!ip || !pepper) {
+    return undefined
+  }
+  return createHmac('sha256', pepper).update(ip).digest('hex').slice(0, 16)
 }
 
 function emit(level: 'info' | 'warn', entry: Record<string, unknown>) {

--- a/apps/web/utils/redis.ts
+++ b/apps/web/utils/redis.ts
@@ -1,0 +1,17 @@
+import { Redis } from '@upstash/redis'
+
+let client: Redis | undefined
+
+/**
+ * Single lazily-initialised Upstash client.
+ *
+ * Vercel reuses warm lambdas, so constructing a client per request wastes
+ * sockets; sharing one module-level instance is safe because the client is
+ * stateless HTTP.
+ */
+export function getRedis(): Redis {
+  if (!client) {
+    client = Redis.fromEnv()
+  }
+  return client
+}

--- a/apps/web/utils/session-owner.ts
+++ b/apps/web/utils/session-owner.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth/next'
+import { Hex, sha256 } from 'viem'
+import { authOptions } from '../pages/api/auth/[...nextauth]'
+
+/**
+ * Stable identifier for the signed-in GitHub user.
+ *
+ * This is the same value `/api/faucet` uses for its per-identity rate-limit
+ * bucket, which is what makes a minted key share its owner's quota rather than
+ * adding a new one.
+ */
+export async function getOwnerHash(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<string | undefined> {
+  try {
+    const session = await getServerSession(req, res, authOptions)
+    const email = session?.user?.email
+    return email ? sha256(email as Hex) : undefined
+  } catch (e) {
+    console.error('Authentication check failed', e)
+    return undefined
+  }
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,27 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const root = path.dirname(fileURLToPath(import.meta.url))
+
+// Next.js resolves bare specifiers like `types` and `utils/captcha-verify`
+// through `baseUrl: "."` in tsconfig.json. Vitest does not read baseUrl, so the
+// same roots are mapped explicitly here.
+const baseUrlDirs = ['components', 'config', 'types', 'utils']
+
+export default defineConfig({
+  resolve: {
+    alias: baseUrlDirs.flatMap((dir) => [
+      { find: new RegExp(`^${dir}$`), replacement: path.resolve(root, dir) },
+      {
+        find: new RegExp(`^${dir}/`),
+        replacement: `${path.resolve(root, dir)}/`,
+      },
+    ]),
+  },
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+    exclude: ['node_modules/**', '.next/**'],
+  },
+})

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,21 @@ yarn --cwd apps/web smoke:api-key \
 
 It exits non-zero if any check fails and never prints the key.
 
+### Verifying the payout path on chain
+
+Every other test mocks the sender, so nothing otherwise proves the hash written
+to `goldTxHash` is a real transaction. `apps/firebase/src/celo-adapter.onchain.test.ts`
+sends a real transfer on Celo Sepolia. It is skipped unless explicitly opted in,
+because it spends gas:
+
+```sh
+RUN_ONCHAIN_TESTS=1 PRIVATE_KEY=<funded key> \
+  yarn --cwd apps/firebase test:ci onchain
+```
+
+The transfer is a self-send, so only the gas fee (~0.0011 CELO at the 50 gwei
+floor) is consumed, and the test asserts the balance falls by exactly that fee.
+
 ### Why not a manually issued key?
 
 Keys are self-serve on purpose. Allowlisted keys need a human to triage each

--- a/readme.md
+++ b/readme.md
@@ -151,8 +151,10 @@ the key path, matching the Coinbase CDP faucet.
 - **Holding two keys does not double your allowance** — the limit is bound to
   the account, not the key, as it is on the Coinbase CDP faucet.
 - The per-address limit is shared with the browser path.
-- A separate daily ceiling applies across all API keys, so programmatic traffic
-  can never starve the browser flow.
+- Two ceilings apply across all API keys: a daily one that bounds total spend,
+  and a 10-minute burst window that bounds arrival rate. The burst window is
+  what stops programmatic traffic locking the payout pool and starving the
+  browser flow.
 - Testnet only. There is no mainnet exposure.
 
 Never commit a key. Keys found in public repositories are revoked without
@@ -168,6 +170,7 @@ Environment variables on the web app:
 | `FAUCET_API_KEY_PEPPER`           | yes      | Secret mixed into the HMAC of every stored key. Without it, key minting and verification both fail closed. Rotating it invalidates every existing key. |
 | `FAUCET_API_KEY_NETWORKS`         | no       | Comma-separated networks that accept key auth. Defaults to `celo-sepolia`.                                                                             |
 | `PROGRAMMATIC_GLOBAL_DAILY_LIMIT` | no       | Daily ceiling across all keys. Defaults to 200.                                                                                                        |
+| `PROGRAMMATIC_BURST_LIMIT`        | no       | Keyed requests allowed per 10 minutes across all keys. Bounds arrival rate so the payout pool cannot be locked. Defaults to 20.                        |
 
 To stop all programmatic traffic immediately without a deploy, set the
 `api-keys:disabled` key in Upstash to any truthy value. The browser flow is

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,84 @@ To set up the firebase app to run locally:
     $ yarn run serve
     ```
 
+## Programmatic access (API keys)
+
+The browser flow is gated on reCAPTCHA v3, which scores headless callers badly
+and cannot be solved without driving a real browser. Scripts and AI agents use
+an API key instead.
+
+### Getting a key
+
+Sign in with GitHub at [`/keys`](https://faucet.celo.org/keys) and create one.
+The key is shown once and only a hash of it is stored, so it cannot be
+recovered — create a new one if you lose it. You may hold up to 2 keys and they
+expire after 90 days.
+
+### Making a request
+
+Send the key as a bearer token and omit `captchaToken`:
+
+```sh
+curl -X POST https://faucet.celo.org/api/faucet \
+  -H "Authorization: Bearer cfk_prd_…" \
+  -H 'Content-Type: application/json' \
+  -d '{"beneficiary":"0xYourAddress","network":"celo-sepolia"}'
+```
+
+A successful call returns `202`-style bookkeeping: `{"status":"Pending","key":"…"}`.
+Poll for the outcome with that key:
+
+```sh
+curl "https://faucet.celo.org/api/status?key=<key>&network=celo-sepolia"
+# {"status":"Done","beneficiary":"0x…","txHash":"0x…"}
+```
+
+Other responses: `400` invalid network or address, `401` missing/invalid/expired
+key, `403` rate limited, `405` wrong method.
+
+### Limits
+
+- Keyed requests count against **your GitHub account's existing daily
+  allowance** (10 per 24h), the same bucket the signed-in browser flow uses. A
+  key changes how you prove who you are, not how much you can request.
+- The per-address limit is shared with the browser path.
+- A separate daily ceiling applies across all API keys, so programmatic traffic
+  can never starve the browser flow.
+- Testnet only. There is no mainnet exposure.
+
+Never commit a key. Keys found in public repositories are revoked without
+notice. If you are integrating a tool that others will install, read the key
+from the user's environment — do not ship a default.
+
+### Operating the key path
+
+Environment variables on the web app:
+
+| Variable                          | Required | Purpose                                                                                                                                                |
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `FAUCET_API_KEY_PEPPER`           | yes      | Secret mixed into the HMAC of every stored key. Without it, key minting and verification both fail closed. Rotating it invalidates every existing key. |
+| `FAUCET_API_KEY_NETWORKS`         | no       | Comma-separated networks that accept key auth. Defaults to `celo-sepolia`.                                                                             |
+| `PROGRAMMATIC_GLOBAL_DAILY_LIMIT` | no       | Daily ceiling across all keys. Defaults to 200.                                                                                                        |
+
+To stop all programmatic traffic immediately without a deploy, set the
+`api-keys:disabled` key in Upstash to any truthy value. The browser flow is
+unaffected. Delete it to re-enable.
+
+### Why not a manually issued key?
+
+Keys are self-serve on purpose. Allowlisted keys need a human to triage each
+request and hand the secret over out of band, which does not scale and tends to
+leave secrets in chat logs. Tying keys to a GitHub account instead reuses an
+identity the faucet already understands, which is also what the Coinbase CDP,
+Circle, and Chainstack faucets do.
+
+### CI pipelines
+
+If you are testing contracts in CI you probably do not want the faucet at all.
+`anvil --fork-url https://forno.celo-sepolia.celo-testnet.org` gives you
+pre-funded accounts against forked state, with no rate limits and no network
+flakiness. Reach for a key only when you need funds on the real testnet.
+
 ## Adding chains
 
 ### Web

--- a/readme.md
+++ b/readme.md
@@ -129,14 +129,27 @@ curl "https://faucet.celo.org/api/status?key=<key>&network=celo-sepolia"
 # {"status":"Done","beneficiary":"0x…","txHash":"0x…"}
 ```
 
-Other responses: `400` invalid network or address, `401` missing/invalid/expired
-key, `403` rate limited, `405` wrong method.
+Other responses carry a machine-readable `error` code so you can branch without
+parsing prose:
+
+| Status | `error`                 | Meaning                                    |
+| ------ | ----------------------- | ------------------------------------------ |
+| `400`  | —                       | Invalid network or beneficiary address     |
+| `401`  | `invalid_api_key`       | Missing, malformed, unknown or expired key |
+| `401`  | `api_key_disabled`      | Programmatic access is switched off        |
+| `429`  | `faucet_limit_exceeded` | Rate limited; honour `Retry-After`         |
+| `405`  | —                       | Wrong HTTP method                          |
+
+The browser flow keeps its existing `403` for rate limits; `429` is used only on
+the key path, matching the Coinbase CDP faucet.
 
 ### Limits
 
 - Keyed requests count against **your GitHub account's existing daily
   allowance** (10 per 24h), the same bucket the signed-in browser flow uses. A
   key changes how you prove who you are, not how much you can request.
+- **Holding two keys does not double your allowance** — the limit is bound to
+  the account, not the key, as it is on the Coinbase CDP faucet.
 - The per-address limit is shared with the browser path.
 - A separate daily ceiling applies across all API keys, so programmatic traffic
   can never starve the browser flow.

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,20 @@ To stop all programmatic traffic immediately without a deploy, set the
 `api-keys:disabled` key in Upstash to any truthy value. The browser flow is
 unaffected. Delete it to re-enable.
 
+### Smoke-testing a deployment
+
+`apps/web/scripts/smoke-api-key.mjs` exercises the whole key path over HTTP —
+rejection of unissued keys, address and method validation, a real payout, the
+status poll, and the returned tx hash. It needs no repo credentials:
+
+```sh
+export FAUCET_API_KEY=cfk_...   # minted at <deployment>/keys
+yarn --cwd apps/web smoke:api-key \
+  --url https://<deployment> --beneficiary 0xYourAddress
+```
+
+It exits non-zero if any check fails and never prints the key.
+
 ### Why not a manually issued key?
 
 Keys are self-serve on purpose. Allowlisted keys need a human to triage each

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,6 +4291,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^1.3.7, accepts@npm:~1.3.5, accepts@npm:~1.3.8":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
+  languageName: node
+  linkType: hard
+
 "accepts@npm:^2.0.0":
   version: 2.0.0
   resolution: "accepts@npm:2.0.0"
@@ -4298,16 +4308,6 @@ __metadata:
     mime-types: "npm:^3.0.0"
     negotiator: "npm:^1.0.0"
   checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
-  languageName: node
-  linkType: hard
-
-"accepts@npm:~1.3.5, accepts@npm:~1.3.8":
-  version: 1.3.8
-  resolution: "accepts@npm:1.3.8"
-  dependencies:
-    mime-types: "npm:~2.1.34"
-    negotiator: "npm:0.6.3"
-  checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
   languageName: node
   linkType: hard
 
@@ -5814,7 +5814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4":
+"content-disposition@npm:0.5.4, content-disposition@npm:^0.5.3":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -6283,6 +6283,13 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
+"depd@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "depd@npm:1.1.2"
+  checksum: 10c0/acb24aaf936ef9a227b6be6d495f0d2eb20108a9a6ad40585c5bda1a897031512fef6484e4fdbb80bd249fdaa82841fa1039f416ece03188e677ba11bcfda249
   languageName: node
   linkType: hard
 
@@ -8235,7 +8242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:0.5.2":
+"fresh@npm:0.5.2, fresh@npm:^0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
@@ -11059,7 +11066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:1.0.3":
+"merge-descriptors@npm:1.0.3, merge-descriptors@npm:^1.0.1":
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
@@ -11087,7 +11094,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"methods@npm:~1.1.2":
+"methods@npm:^1.1.2, methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
@@ -11153,7 +11160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:1.6.0":
+"mime@npm:1.6.0, mime@npm:^1.3.4":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
@@ -11772,6 +11779,31 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10c0/abddfff7d873312e4ed4a5fb75ce893a5c4fb69e7fcb1dfa71c28a6b92a7f1ef6b62790dffb39181b5a82728ba8f2f32d229cf8cbe66769fe02cea7db4a555aa
+  languageName: node
+  linkType: hard
+
+"node-mocks-http@npm:^1.18.1":
+  version: 1.18.1
+  resolution: "node-mocks-http@npm:1.18.1"
+  dependencies:
+    accepts: "npm:^1.3.7"
+    content-disposition: "npm:^0.5.3"
+    depd: "npm:^1.1.0"
+    fresh: "npm:^0.5.2"
+    merge-descriptors: "npm:^1.0.1"
+    methods: "npm:^1.1.2"
+    mime: "npm:^1.3.4"
+    range-parser: "npm:^1.2.0"
+    type-is: "npm:^1.6.18"
+  peerDependencies:
+    "@types/express": ^4.17.21 || ^5.0.0
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/express":
+      optional: true
+    "@types/node":
+      optional: true
+  checksum: 10c0/8163cf81688c7a45d2da6cd3c5222fe55ad625797521253bfce91c8453dba7238b843a78f3f086f15c46e66a8ec5745da3d2f358c51543384bf61e6389ca8d1d
   languageName: node
   linkType: hard
 
@@ -13082,6 +13114,13 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.1.0"
   checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "range-parser@npm:1.3.0"
+  checksum: 10c0/295494bb6685f9ab50f41a5f4fa5ce445aeeb9673b491bf178460fcc3a812dcf0d164cf1c83074f13a71a87d91ead5e097afd53e0630bc49a5101ed60f2a7529
   languageName: node
   linkType: hard
 
@@ -15214,6 +15253,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^1.6.18, type-is@npm:~1.6.18":
+  version: 1.6.18
+  resolution: "type-is@npm:1.6.18"
+  dependencies:
+    media-typer: "npm:0.3.0"
+    mime-types: "npm:~2.1.24"
+  checksum: 10c0/a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
+  languageName: node
+  linkType: hard
+
 "type-is@npm:^2.0.0, type-is@npm:^2.0.1":
   version: 2.0.1
   resolution: "type-is@npm:2.0.1"
@@ -15233,16 +15282,6 @@ __metadata:
     media-typer: "npm:^1.1.0"
     mime-types: "npm:^3.0.0"
   checksum: 10c0/a6018f8f509de48f2c7429305e3a920e73b374fa93127dd0877ae1c2df65a5d33907caac8afb0c37a9b9fc7c49f29e3f55d668963dc845d966930b667c07f50e
-  languageName: node
-  linkType: hard
-
-"type-is@npm:~1.6.18":
-  version: 1.6.18
-  resolution: "type-is@npm:1.6.18"
-  dependencies:
-    media-typer: "npm:0.3.0"
-    mime-types: "npm:~2.1.24"
-  checksum: 10c0/a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
   languageName: node
   linkType: hard
 
@@ -15833,6 +15872,7 @@ __metadata:
     next: "npm:15.5.9"
     next-auth: "npm:^4.24.11"
     next-themes: "npm:^0.4.6"
+    node-mocks-http: "npm:^1.18.1"
     postcss: "npm:^8.5.6"
     react: "npm:19.2.1"
     react-dom: "npm:19.2.1"
@@ -15844,6 +15884,7 @@ __metadata:
     tw-animate-css: "npm:^1.3.8"
     typescript: "npm:5.5.3"
     viem: "npm:^2.33.2"
+    vitest: "npm:^1.6.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

reCAPTCHA v3 scores headless callers badly and can't be solved without driving a real browser, so scripts and AI agents can't use the faucet at all. The immediate driver is a `request_faucet_funds` tool for `celo-org/celo-mcp`.

This adds an API-key path to `POST /api/faucet`. Keys are **self-serve**: sign in with GitHub at `/keys` and mint one. Stored as an HMAC with a server-side pepper, indexed by hash so verification is a lookup with no timing oracle, 90-day expiry, max 2 per account, instant revocation.

The central design property: **keyed requests share the owner's existing per-identity rate-limit bucket**, so a key changes how you prove who you are, not how much you get — matching this issue's own stated non-goal. Holding two keys does not double your allowance.

Two ceilings bound keyed traffic across all keys: a **daily** one (200/day) capping total spend, and a **10-minute burst window** (20) capping arrival rate — the latter is what stops keyed traffic locking the payout pool and starving the browser path.

Keyed requests write the existing `AuthLevel.authenticated`, so **no new enum value and no database-rules redeploy** — this ships as a Vercel-only deploy, revertible by rollback.

Also adds `GET /api/status`, because a programmatic caller previously had no way to learn whether a payout landed (the browser subscribes over an RTDB websocket).

#### Alignment with the Coinbase CDP faucet

The rate-limit architecture deliberately mirrors CDP's, which is the strongest part of their design:

| Property | CDP | This PR |
| --- | --- | --- |
| Allowance bound to the account, not the key | ✅ | ✅ |
| Two keys ≠ double allowance | ✅ | ✅ |
| Per-destination-address cap holding across accounts | ✅ | ✅ (`rate-limits:<beneficiary>`) |
| Self-serve issuance, secret shown once | ✅ | ✅ |
| No captcha on the API path | ✅ | ✅ |
| `429` + machine-readable limit code | ✅ `faucet_limit_exceeded` | ✅ same code |
| Hash at rest, greppable key prefix | ❌ (bare UUID, unscannable) | ✅ `cfk_prd_…` |
| Automatic key expiry | ❌ none | ✅ 90 days |

**One deliberate divergence: credential format.** CDP requires minting a short-lived ES256/EdDSA JWT; a raw key is never sent. We use an opaque bearer token, like Circle and Chainstack. CDP is 1-of-3 here, and the reason is legible — their key also controls **Server Wallets holding real mainnet funds**, and the faucet just sits behind the same gateway. Copying it here would mean:

- `curl` in the README stops working (Coinbase had to ship [`cdpcurl`](https://github.com/coinbase/cdpcurl) precisely because of this)
- a public MCP server would have to hold the **long-lived signing secret** to mint tokens, making it a signing oracle and destroying per-caller attribution
- hand-rolling a JWT verifier (`alg: none`, algorithm confusion, `exp` handling) to protect testnet tokens worth nothing

Happy to revisit if this credential ever gains scope beyond the faucet — that's the point at which the blast radius justifies it.

**Second deliberate divergence: claim shape — with measurements.** CDP issues many tiny claims (1000/day × 0.0001 ETH); this PR issues few large ones (10/day × 3 CELO). CDP can do that because Base Sepolia gas is effectively free. Celo Sepolia has a hard **50 gwei base-fee floor** (measured flat across 5,000 blocks), so a drip has to be a meaningful lump to be usable at all:

| Drip | Simple transfers | ERC-20 transfers | Contract deploys |
| --- | --- | --- | --- |
| 0.3 CELO (unauthenticated) | 272 | 87 | **2** |
| 3 CELO (authenticated / keyed) | 2,721 | 879 | **28** |

Adopting CDP's numbers here would copy their arithmetic while discarding the reason for it, and would leave keyed callers unable to deploy anything. Keeping the existing authenticated tier also avoids a third `AuthLevel`, and therefore a `database-rules.bolt` edit and redeploy. It stays non-breaking to revisit later once the new metrics show real agent traffic.

This also makes the payout bug below more consequential than it first appears: mainnet-holding addresses were getting two contract deploys' worth while the UI promised twenty-eight.

### Other changes

Three pre-existing bugs found in the lines being modified:

- **`addressCanBeElevatedToTrusted` never reached the payout.** `newRequest` captured `authLevel` at `firebase.serverside.ts:87` before the elevation reassigned it at `:91`, so mainnet-holding addresses got 0.3 CELO instead of 3. **Not a product change** — the on-page rules card has advertised "10x the amount" for exactly these addresses all along; the code never did it. This restores documented behaviour.
- **`dispatchCeloFunds` wrote `celoTxhash`** while the record type, database rules and UI all read `goldTxHash` — the "View on Celo Explorer" link has been permanently dead.
- **User rate-limit bucket TTL** was hardcoded to the authenticated period.

Plus: the web app had zero tests and no test runner; added vitest and a CI step. Session lifetime raised from a 60s JWT / 2min session to 15min, because a 60-second JWT makes any authenticated UI impossible. That grants no extra funds — the durable control is the `sha256(email)` bucket, which survives across sessions.

### Tested

```
lint                    ✔ No ESLint warnings or errors
web tsc --noEmit        exit=0
firebase tsc -b         exit=0
web vitest              56 passed (56)
firebase vitest         17 passed (17), +1 opt-in on-chain   (12 before)
next build              ✓ compiled, routes correct
```

Tests run through the real route handler seam (`apps/web/tests/faucet.test.ts` → `pages/api/faucet.ts` via `node-mocks-http`), not just pure functions.

**Mutation testing** — each core fix reverted in turn, suite re-run, then restored:

| Mutation | Tests red |
| --- | --- |
| Elevation ordering reverted (the original bug) | 2 |
| Keyed request given its own quota bucket | 1 |
| Channel branching disabled | 3 |
| Invalid API key no longer rejected | 3 |
| Owner identity dropped on keyed path | 2 |
| Network allowlist guard removed | 1 |
| Beneficiary validation removed | 4 |
| `429` reverted to `403` on the key path | 1 |
| `goldTxHash` fix reverted | **0 → 1** |
| 503 guard on key-verification failure removed | 1 |
| Programmatic burst bucket removed | 2 |
| Burst window widened to 24h | 1 |

The `goldTxHash` fix initially had **zero** coverage. `apps/firebase/src/database-helper.test.ts` (5 tests through the exported `processRequest`) was added so it now goes red.

Two bugs were caught by tests during development: a test file under `pages/api/` was being emitted as a live `/api/faucet.test` route, and base64url secrets contain `_` so splitting keys on `_` broke parsing (now an anchored regex plus a 200-iteration fuzz test).

**End-to-end:** `apps/web/scripts/smoke-api-key.mjs` drives the whole path over HTTP against a deployment. Run against current production (old code) it correctly shows the baseline — no key path, no method check, no address validation:

```
PASS  unissued key rejected with 401
PASS  no credential is rejected (captcha path) — got 401
FAIL  invalid address rejected with 400 — got 401
FAIL  GET rejected with 405 — got 400
FAIL  valid key accepted with 200 and no captcha — got 401 invalid-input-response
```

The same script should go green against this branch's preview deployment once `FAUCET_API_KEY_PEPPER` is set. **That run has not happened yet** — see below.

**On-chain, the payout half is now verified for real.** Every other test mocks `transferCelo`, so nothing proved the hash written to `goldTxHash` is a resolvable transaction. `apps/firebase/src/celo-adapter.onchain.test.ts` sends a real transfer on Celo Sepolia (opt-in via `RUN_ONCHAIN_TESTS=1`, skipped in CI):

```
tx        0xb45faa5e593d79b8e206ca34c924f852c113e01e74fcd6915a116c7ce8cdadcc
status    success
block     34451774
gas used  21000 @ 52500000000 wei
fee       0.0011025 CELO
delta     0.0011025 CELO (self-send)
```

The transfer is a self-send, so only gas moves, and the test asserts the balance falls by *exactly* the receipt fee. Writing that test surfaced a real trap worth knowing: reading balances at `latest` right after a receipt lands silently reports a zero delta, because Forno is load balanced and a replica can still be serving pre-transaction state — or reject the block as out of range. The test reads at explicit block numbers with a retry.

### What this does NOT do / residual risk

- **The E2E run against a real deployment is still outstanding.** It needs `FAUCET_API_KEY_PEPPER` set in Vercel; the key path fails closed without it. Everything above is local evidence only.
- **Worst case if every key leaks: 200 requests/day × 3 CELO = 600 CELO/day**, bounded by the global ceiling and tunable via env without a deploy. Arrival rate is separately capped at 20 per 10 minutes.
- **Detection latency is the weak point.** Revocation is sub-second once a human acts, but nobody watches Vercel logs by default; no alerting is wired up.
- Long-lived bearer tokens leak through logs, shell history and pasted curl commands — outside TLS. Mitigated by the greppable `cfk_` prefix (enables secret scanning), hash-at-rest, 90-day expiry and one-click revoke. Neither CDP, Circle nor Chainstack is a GitHub secret-scanning partner; we can be.
- Sybil cost is one GitHub account — the same cost already applying to the browser authenticated tier, not made worse.
- `/keys` has no component tests (no jsdom/RTL in this repo); verified by build and typecheck only.

### Related issues

`Refs #272`

Every technical item in the issue is addressed — auth model, key storage, rate-limit policy, abuse surface, network scope, observability, and the x402 evaluation — and all three non-goals hold. Not `Closes` because the issue asks for these decisions to be discussed before implementation, and four diverge from what it proposed (self-serve rather than allowlist; Redis rather than Firestore; reuse `AuthLevel.authenticated` rather than a new tier; per-owner rather than per-key limits). Close it once a maintainer signs off.

**x402 and ERC-8004 were evaluated and rejected** (issue items 1 and 7). x402's facilitator is verify+settle over EIP-3009 — a payment rail, not an identity oracle. Paying in testnet USDC to get testnet CELO is circular; paying in mainnet USDC would make Celo the first chain to charge for testnet funds; and `/verify` without `/settle` collapses into the mainnet-balance check `addressCanBeElevatedToTrusted` already performs, with two published free-riding attack classes against that pattern. ERC-8004 registration is permissionless and cheap, so agent identity adds no Sybil resistance, and reputation has a cold-start problem that reduces back to an allowlist. No faucet anywhere uses either.

The `request_faucet_funds` follow-up in `celo-org/celo-mcp` needs its own issue.

### Backwards compatibility

Fully compatible. `request-form.tsx` never sets `Authorization`, so the browser always takes the unchanged path — a contract test asserts byte-identical status codes and messages, including that the browser keeps its `403` while the key path returns `429`.

Behaviour deltas: an invalid address now returns `400` instead of `404`; `GET` returns `405` instead of `500`; mainnet-holding addresses now receive the 3 CELO the UI already promised.

### Documentation

- `readme.md` — new **Programmatic access (API keys)** section: minting, the bearer header, full response/error-code table, limits, the operator runbook (env vars + kill switch), the smoke test, why not a manually issued key, and the `anvil --fork-url` path for CI.
- On-page faucet rules now mention the key path; the request card links to `/keys`.

### Merge order

| PR | Overlap | Note |
| --- | --- | --- |
| **#265** Firebase Admin SDK | `firebase.serverside.ts`, `package.json`, `yarn.lock` | **Real conflict.** It makes `getDB()` synchronous; `getRequestRecord` and `sendRequest` both call it. Suggest **#265 first, then rebase this** — its hunks are confined to the init block and two call sites. |
| **#268** typo fixes | `database-helper.ts`, `readme.md` | Textual, trivial |
| **#270** vitest v3 | `apps/firebase/package.json`, `yarn.lock` | Web is pinned to `^1.6.1` to match firebase; whoever merges second should align both. |

### Remaining ops steps

- [ ] Set `FAUCET_API_KEY_PEPPER` in Vercel (production + preview + development) — **the key path fails closed without it**
- [ ] Optionally set `FAUCET_API_KEY_NETWORKS`, `PROGRAMMATIC_GLOBAL_DAILY_LIMIT`
- [ ] Run `apps/web/scripts/smoke-api-key.mjs` against the preview deployment and paste the output here
- [ ] Deploy firebase functions for the `goldTxHash` fix (no rules redeploy needed)
- [ ] Add a GitHub secret-scanning custom pattern for `cfk_prd_` with push protection
- [ ] Wire an alert at 60% of the global daily ceiling

### Review round

A self-review found and fixed two defects, both with red→green mutation proof:

1. **No burst bound on the key path** (`firebase.serverside.ts`). Every keyed bucket used a 24h window, so a day's worth of requests could arrive at once, lock every account in the payout pool and starve the browser path with `NoFreeAccountErr`. An earlier draft of this description claimed the daily ceiling prevented starvation — it does not; only a burst window does. Fixed by adding `api-key-counts:burst` (20 per 10 min), and the readme corrected.
2. **Unhandled rejection on key verification** (`faucet.ts`). `verifyKey` reaches Redis and throws when `FAUCET_API_KEY_PEPPER` is absent; that rejection escaped the handler with no response written, so a misconfigured deploy returned an opaque 500. Now fails closed with `503` + `Retry-After`.

### Questions for the maintainer

1. **The unauthenticated tier may be too small.** At 50 gwei, 0.3 CELO buys about **two contract deploys** (see the gas analysis above). A first-time dev hits that wall immediately. Pre-existing and out of scope here, but it probably deserves its own issue.
2. **Per-key IP allowlist.** CDP offers one at key creation. Cheap to add later; worth doing now?
3. Sanity-check the 200/day global ceiling against the pool's actual balance — I can't read the RTDB-held payout keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

