### PR TITLE
fix(faucet): set the GitHub OAuth issuer so sign-in works again

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -21,6 +21,13 @@ export const authOptions: AuthOptions = {
     GithubProvider({
       clientId: process.env.GITHUB_ID || '',
       clientSecret: process.env.GITHUB_SECRET || '',
+      // GitHub now returns the RFC 9207 `iss` parameter on the callback.
+      // openid-client validates it against the issuer, and next-auth 4.24.13's
+      // GitHub provider does not set one, so every sign-in fails with
+      // "issuer must be configured on the issuer". Upstream added this same
+      // value in 4.24.14; setting it here fixes sign-in without waiting on the
+      // dependency bump, and deep-merges harmlessly once that lands.
+      issuer: 'https://github.com/login/oauth',
     }),
   ],
   callbacks: {

--- a/apps/web/tests/auth-options.test.ts
+++ b/apps/web/tests/auth-options.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { authOptions } from '../pages/api/auth/[...nextauth]'
+
+/**
+ * GitHub sends the RFC 9207 `iss` parameter on the OAuth callback.
+ * openid-client asserts an issuer is configured before comparing it, so a
+ * provider without one fails every sign-in with
+ * "issuer must be configured on the issuer".
+ *
+ * The provider factory nests user-supplied options under `.options`, and
+ * next-auth merges them onto the provider in `core/lib/providers.js` before
+ * `core/lib/oauth/client.js` reads `provider.issuer`. That merge is verified
+ * separately; these assertions cover the half this repo owns — that an issuer
+ * is supplied at all, and that it matches the endpoints it will be compared
+ * against.
+ */
+type OAuthish = {
+  id: string
+  authorization?: { url?: string } | string
+  token?: { url?: string } | string
+  options?: { issuer?: string }
+}
+
+const urlOf = (v: { url?: string } | string | undefined) =>
+  typeof v === 'string' ? v : v?.url
+
+function github(): OAuthish {
+  const provider = (authOptions.providers as unknown as OAuthish[]).find(
+    (p) => p.id === 'github',
+  )
+  if (!provider) {
+    throw new Error('GitHub provider is not configured')
+  }
+  return provider
+}
+
+describe('GitHub auth provider', () => {
+  // Regression: without an issuer, every sign-in dies at the callback.
+  it('supplies an issuer', () => {
+    expect(github().options?.issuer).toBeTruthy()
+  })
+
+  it('uses an issuer that both OAuth endpoints sit under', () => {
+    const provider = github()
+    const issuer = provider.options?.issuer as string
+
+    // A wrong-but-present issuer swaps the crash for an "iss mismatch", so the
+    // value matters as much as its presence.
+    expect(urlOf(provider.authorization)?.startsWith(issuer)).toBe(true)
+    expect(urlOf(provider.token)?.startsWith(issuer)).toBe(true)
+  })
+
+  it('uses an https issuer with no trailing slash', () => {
+    expect(github().options?.issuer).toMatch(/^https:\/\/\S+[^/]$/)
+  })
+})


### PR DESCRIPTION
### Description

**GitHub sign-in is currently broken on faucet.celo.org.** Every attempt fails at the callback and loops back to the sign-in page with "Try signing in with a different account." Production logs:

```
[next-auth][error][OAUTH_CALLBACK_ERROR]
https://next-auth.js.org/errors#oauth_callback_error
issuer must be configured on the issuer
{ error: Error [OAuthCallbackError], providerId: 'github' }
```

GitHub has rolled out [RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207), which adds an `iss` parameter to the OAuth callback. `openid-client` validates it, but asserts the issuer is configured first:

```js
// openid-client/lib/client.js:556
if ('iss' in params) {
  assertIssuerConfiguration(this.issuer, 'issuer')   // throws when undefined
```

`next-auth@4.24.13`'s GitHub provider sets no `issuer`, and `core/lib/oauth/client.js` passes `issuer: provider.issuer` straight through — so the assertion fires on every sign-in.

This affects the **existing GitHub tier** (10x tokens), not only the new API-key page.

### Other changes

Adds `apps/web/tests/auth-options.test.ts`, covering both failure modes: a missing issuer, and a present-but-wrong one (which would swap the crash for an `iss mismatch`).

### Tested

Verified against the installed packages rather than inferred. Running next-auth's own provider normalisation — the same `parseProviders` step the runtime applies before `core/lib/oauth/client.js` reads `provider.issuer`:

```
WITHOUT the fix -> provider.issuer = undefined
WITH    the fix -> provider.issuer = "https://github.com/login/oauth"
authorization url                  = https://github.com/login/oauth/authorize
token url                          = https://github.com/login/oauth/access_token

openid-client would throw without it : true
openid-client satisfied with it      : true
issuer is a prefix of both endpoints : true
```

That last line matters: a present-but-wrong issuer trades the crash for `iss mismatch, expected X, got Y`. The value is the common base of both endpoints, which is also what upstream chose.

Worth noting the provider factory nests user options under `.options` rather than spreading them, so the raw config object still shows `issuer: undefined`. An earlier version of the test asserted on the raw object and failed against a working fix — the check above is what settled it.

```
web vitest   70 passed (70)   (67 before, +3)
tsc          exit 0
lint         clean
build        compiled
```

Mutation-tested:

| Mutation | Tests red |
| --- | --- |
| issuer removed (reproduces production) | 3 |
| issuer set to a wrong value | 1 |

**Not verified:** a real end-to-end sign-in, which needs a browser GitHub login against a deployment carrying this change. The mechanism is confirmed at the point openid-client throws, but the round trip itself is unproven until this is deployed.

### Related issues

None open for this. Note #271 (`next-auth` → 4.24.15) fixes the same thing upstream — 4.24.14 added exactly this one line to `providers/github.js`. The two are compatible: an explicit `issuer` deep-merges to the same value. This is the smaller, faster change, and doesn't require moving the lockfile on a live outage.

### Backwards compatibility

Compatible. One added provider option; no change to session handling, callbacks, or any route. It restores previously-working behaviour rather than changing it.

### Documentation

None needed — no user-facing surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
