### PR TITLE
fix(faucet): explain sign-in failures instead of looping the visitor

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -46,6 +46,12 @@ export const authOptions: AuthOptions = {
       return session
     },
   },
+  // next-auth's built-in error page only offers "Try signing in with a
+  // different account", which sends people round a loop when the cause is
+  // server-side. /auth-error names what happened and who can fix it.
+  pages: {
+    error: '/auth-error',
+  },
   // Long enough to mint and copy an API key on /keys. Sessions only select the
   // authenticated tier; the durable control is the per-identity rate-limit
   // bucket keyed on sha256(email), which survives across sessions, so a longer

--- a/apps/web/pages/auth-error.tsx
+++ b/apps/web/pages/auth-error.tsx
@@ -1,0 +1,125 @@
+import { NextPage } from 'next'
+import Head from 'next/head'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '../@/components/ui/card'
+import { FaucetHeader } from 'components/faucet-header'
+import styles from 'styles/Home.module.css'
+import { inter } from 'utils/inter'
+
+/**
+ * next-auth's built-in error page says only "Try signing in with a different
+ * account", which is misleading when the cause is server-side — the visitor
+ * changes account, fails again, and has no way to tell it was never their
+ * fault. These messages say who can fix it.
+ */
+const MESSAGES: Record<string, { title: string; detail: string }> = {
+  Configuration: {
+    title: 'The faucet is misconfigured',
+    detail:
+      'Sign-in cannot complete because of a server-side setting. Nothing you do differently will help — please report this.',
+  },
+  OAuthCallback: {
+    title: 'GitHub sign-in could not be completed',
+    detail:
+      'GitHub sent us back but the response was rejected. This is a problem on the faucet side, not with your account.',
+  },
+  OAuthSignin: {
+    title: 'Could not reach GitHub',
+    detail:
+      'The faucet failed to start the GitHub sign-in. This is usually temporary — try again in a moment.',
+  },
+  OAuthAccountNotLinked: {
+    title: 'That account is already linked elsewhere',
+    detail: 'Sign in with the same GitHub account you used the first time.',
+  },
+  AccessDenied: {
+    title: 'GitHub access was declined',
+    detail:
+      'You cancelled the authorisation, or GitHub refused it. Try again and approve the request.',
+  },
+  Verification: {
+    title: 'That sign-in link has expired',
+    detail: 'Request a new one and use it straight away.',
+  },
+  SessionRequired: {
+    title: 'You need to be signed in',
+    detail: 'Sign in with GitHub to continue.',
+  },
+}
+
+const FALLBACK = {
+  title: 'Sign-in failed',
+  detail:
+    'Something went wrong while signing in. If it keeps happening it is likely a problem on the faucet side rather than with your account.',
+}
+
+const AuthError: NextPage = () => {
+  const { query } = useRouter()
+  const code = typeof query.error === 'string' ? query.error : undefined
+  const { title, detail } = (code && MESSAGES[code]) || FALLBACK
+
+  return (
+    <>
+      <Head>
+        <title>Sign-in problem</title>
+        <meta name="robots" content="noindex" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main className={styles.main}>
+        <FaucetHeader network="celo-sepolia" isOutOfCELO={false} />
+
+        <Card className="w-full max-w-lg items-stretch">
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+          </CardHeader>
+
+          <CardContent className="flex flex-col gap-4">
+            <p className={`${inter.className} text-sm`} role="alert">
+              {detail}
+            </p>
+
+            <div className="flex flex-col gap-0.5 items-start text-sm">
+              <small className={inter.className}>
+                &bull;{' '}
+                <Link className="underline" href="/api/auth/signin/github">
+                  Try signing in again
+                </Link>
+              </small>
+              <small className={inter.className}>
+                &bull;{' '}
+                <Link className="underline" href="/celo-sepolia">
+                  Use the faucet without signing in
+                </Link>{' '}
+                — you still get tokens, just a smaller amount
+              </small>
+              <small className={inter.className}>
+                &bull;{' '}
+                <Link
+                  className="underline"
+                  href="https://github.com/celo-org/faucet/issues/new/choose"
+                >
+                  Report this
+                </Link>
+                {code ? (
+                  <>
+                    {' '}
+                    and quote <code>{code}</code>
+                  </>
+                ) : null}
+              </small>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </>
+  )
+}
+
+export default AuthError

--- a/apps/web/tests/auth-error-page.test.ts
+++ b/apps/web/tests/auth-error-page.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { authOptions } from '../pages/api/auth/[...nextauth]'
+
+/**
+ * next-auth only shows "Try signing in with a different account" for most
+ * failures, including server-side ones, which sends people round a loop
+ * changing accounts that were never the problem.
+ */
+describe('auth error routing', () => {
+  it('routes failures to a page we control', () => {
+    expect(authOptions.pages?.error).toBe('/auth-error')
+  })
+
+  // Regression: an error page that is itself the sign-in page loops.
+  it('does not point errors at the sign-in route', () => {
+    expect(authOptions.pages?.error).not.toMatch(/signin/i)
+  })
+
+  it('leaves the sign-in page as the next-auth default', () => {
+    // Overriding signIn would hijack the faucet page's own auth link.
+    expect(authOptions.pages?.signIn).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Description

When GitHub sign-in fails, next-auth's built-in error page says only **"Try signing in with a different account"** — for nearly every failure code, including ones that are entirely server-side.

During the OAuth outage fixed in #275, that meant a visitor clicked sign in, got bounced to a page telling them to change account, changed account, failed again, and had nothing on screen indicating the fault was ours. The observed behaviour was "nothing happens, it just reloads or redirects".

This routes next-auth errors to `/auth-error`, a page we control, which:

- names what actually happened, per error code
- says plainly whether the visitor can do anything about it
- points at the **unauthenticated faucet, which keeps working** — the important escape hatch, since sign-in is optional
- shows the error code to quote in a report

`pages.signIn` is deliberately left at the default so the faucet page's own auth link is untouched.

### Other changes

None.

### Tested

```
web vitest   73 passed (73)   (70 before, +3)
tsc          exit 0
lint         clean
build        compiled, /auth-error emitted as a static route
```

Rendered and inspected at `/auth-error?error=OAuthCallback` — carries the site header, logo and theme toggle like every other page, and reads:

> **GitHub sign-in could not be completed**
> GitHub sent us back but the response was rejected. This is a problem on the faucet side, not with your account.

Tests assert the routing rather than the copy: that `pages.error` is set, that it does not point back at a sign-in route (which would loop), and that `pages.signIn` stays undefined so the existing flow is unaffected.

**Not verified:** a real failing sign-in against a deployment. The mapping is exercised by rendering each code, but the next-auth redirect into this page has not been observed in production — by design, since the underlying fault is fixed.

### Related issues

Follow-up from #275. Refs the outage that motivated it.

### Backwards compatibility

Compatible. Adds one route and one `pages.error` entry. No change to sign-in, session handling, callbacks, or any API route.

### Documentation

None needed — the page is self-describing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
