### PR TITLE
feat(faucet): raise the unauthenticated drip to 1 CELO

### DIFF
--- a/apps/firebase/src/config.test.ts
+++ b/apps/firebase/src/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { getNetworkConfig } from './config'
+
+const CELO = BigInt(10) ** BigInt(18)
+
+/**
+ * Payout amounts are a funding decision, not an implementation detail, so
+ * they are pinned here: changing one should be deliberate and should force
+ * the on-page copy in apps/web/pages/[chain].tsx to be revisited with it.
+ */
+describe('celo-sepolia payout amounts', () => {
+  const config = getNetworkConfig('celo-sepolia')
+
+  // Raised from 0.3: at Celo Sepolia's 50 gwei floor that bought only about
+  // two contract deployments, which a first session could exhaust.
+  it('pays 1 CELO unauthenticated', () => {
+    expect(config.faucetGoldAmount).toBe(CELO)
+  })
+
+  it('pays 3 CELO authenticated', () => {
+    expect(config.authenticatedGoldAmount).toBe(BigInt(3) * CELO)
+  })
+
+  // The on-page rules state this multiple; if it moves, that copy is wrong.
+  it('keeps the authenticated tier at 3x the unauthenticated one', () => {
+    expect(config.authenticatedGoldAmount / config.faucetGoldAmount).toBe(
+      BigInt(3),
+    )
+  })
+
+  it('keeps authenticated strictly better than unauthenticated', () => {
+    expect(config.authenticatedGoldAmount).toBeGreaterThan(
+      config.faucetGoldAmount,
+    )
+  })
+})

--- a/apps/firebase/src/config.ts
+++ b/apps/firebase/src/config.ts
@@ -10,7 +10,10 @@ export interface NetworkConfig {
 
 const CELO_SEPOLIA_CONFIG: NetworkConfig = {
   nodeUrl: 'https://forno.celo-sepolia.celo-testnet.org',
-  faucetGoldAmount: 300_000_000_000_000_000n,
+  // Celo Sepolia holds a 50 gwei base-fee floor, so 0.3 CELO covered only
+  // about two contract deployments — a first session could exhaust it without
+  // doing anything unusual. 1 CELO is roughly nine.
+  faucetGoldAmount: 1_000_000_000_000_000_000n,
   authenticatedGoldAmount: 3_000_000_000_000_000_000n,
 }
 

--- a/apps/firebase/src/config.ts
+++ b/apps/firebase/src/config.ts
@@ -10,9 +10,10 @@ export interface NetworkConfig {
 
 const CELO_SEPOLIA_CONFIG: NetworkConfig = {
   nodeUrl: 'https://forno.celo-sepolia.celo-testnet.org',
-  // Celo Sepolia holds a 50 gwei base-fee floor, so 0.3 CELO covered only
-  // about two contract deployments — a first session could exhaust it without
-  // doing anything unusual. 1 CELO is roughly nine.
+  // Celo Sepolia holds a 50 gwei base-fee floor, and a measured transfer paid
+  // 52.5 gwei effective. At that price 0.3 CELO covered only two or three
+  // contract deployments — a first session could exhaust it without doing
+  // anything unusual. 1 CELO is nine or ten.
   faucetGoldAmount: 1_000_000_000_000_000_000n,
   authenticatedGoldAmount: 3_000_000_000_000_000_000n,
 }

--- a/apps/firebase/vitest.config.ts
+++ b/apps/firebase/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // config.ts asserts GCLOUD_PROJECT at module load, so importing anything
+    // that reaches it throws unless the variable is present. Setting it here
+    // keeps the suite runnable from a clean shell and in CI, rather than only
+    // on a machine that happens to have it exported.
+    env: {
+      GCLOUD_PROJECT: 'celo-faucet',
+    },
+  },
+})

--- a/apps/web/pages/[chain].tsx
+++ b/apps/web/pages/[chain].tsx
@@ -52,7 +52,7 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
               {!session && (
                 <>
                   <small className={inter.className}>
-                    &bull; To receive <b>10x the tokens</b>,{' '}
+                    &bull; To receive <b>3x the tokens</b>,{' '}
                     <Link className="underline" href="/api/auth/signin/github">
                       authenticate with GitHub
                     </Link>
@@ -107,7 +107,7 @@ const Home: NextPage<Props> = ({ isOutOfCELO, network }: Props) => {
               </p>
               <p className={inter.className}>
                 &bull; You may faucet 10 times a day if <i>authenticated</i>,
-                for 10 times the amount of unauthenticated requests.
+                for 3 times the amount of unauthenticated requests.
               </p>
               <p className={inter.className}>
                 &bull; Requests made with an{' '}


### PR DESCRIPTION
### Description

Raises the unauthenticated drip from **0.3 to 1 CELO**.

Celo Sepolia enforces a **50 gwei base-fee floor** — measured flat across 5,000 consecutive blocks — and a real transfer billed `21000 gas @ 52.5 gwei` effective. The table below uses the measured 52.5 gwei, which is the conservative figure; at the 50 gwei floor each row is about 5% higher (0.3 CELO buys 3 deploys, 1.0 buys 10):

| Drip | Simple transfers | ERC-20 transfers | Contract deploys (~2M gas) |
| --- | --- | --- | --- |
| 0.3 CELO (before) | 272 | 87 | **2** |
| **1.0 CELO (after)** | 907 | 290 | **9** |
| 3.0 CELO (authenticated) | 2,721 | 879 | 28 |

Two deployments is inside a single first session. A developer trying the chain for the first time — exactly who the faucet is for — could exhaust the tier without doing anything unusual.

### Other changes

**The multiple drops from 10x to 3x**, since the authenticated tier stays at 3 CELO. Two pieces of copy said 10x and are now wrong, so both are updated:

- `[chain].tsx:55` — "To receive **10x** the tokens" → **3x**
- `[chain].tsx:110` — "for 10 times the amount" → **3 times**

`apps/firebase/src/config.test.ts` now pins both amounts *and* the ratio, so the numbers and the on-page copy cannot drift apart again — the existing `get-qualified-mount` test uses a mock config and never touched the real values.

### Tested

Funding checked on-chain first, since this is the one thing that constrains the decision:

```
0x127c22b9…65f8   (payout account)    1,465.78 CELO
0x1724707c…3c06   (treasury)      1,086,662.26 CELO
```

Two ceilings move:

| | before | after |
| --- | --- | --- |
| per address / 24h (4 requests) | 1.2 CELO | **4 CELO** |
| global unauthenticated / day (3 per 10 min) | 129.6 CELO | **432 CELO** |

432 CELO/day against a 1,466 CELO payout account is ~3.4 days of sustained maximum abuse before it needs a top-up from the 1.09M treasury — and that is the theoretical ceiling, not observed load. Worth a maintainer's judgement, but not close to a funding problem.

```
firebase vitest   4 files passed, 1 skipped   (+4 new)
firebase tsc      exit 0
web tsc           exit 0
lint              clean
build             compiled
```

**Not verified:** a payout at the new amount, which needs a deploy. `getQualifiedAmount` reads straight from this config and is already covered.

### Related issues

Closes #277.

### Backwards compatibility

Compatible — a config value and two strings. No schema, API or auth change. Reverting is a one-line change.

Worth a maintainer's eye: the 10x → 3x reduction weakens the incentive to sign in. I judged the unusable floor to be the bigger problem, and #277 has the costed alternatives if you would rather keep a wider gap by raising the authenticated tier instead.

### Documentation

On-page faucet rules updated. No readme change — it does not quote amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

