### PR TITLE
feat(faucet): make the logo a link home and add a For Agents nav item

### DIFF
--- a/apps/web/components/faucet-header.tsx
+++ b/apps/web/components/faucet-header.tsx
@@ -12,9 +12,6 @@ interface Props {
   isOutOfCELO: boolean
 }
 
-/** The faucet itself. Every page can get back here. */
-export const HOME_HREF = '/celo-sepolia'
-
 export const FaucetHeader: FC<Props> = ({ network, isOutOfCELO }) => (
   <div className={styles.top}>
     {isOutOfCELO && (
@@ -27,8 +24,13 @@ export const FaucetHeader: FC<Props> = ({ network, isOutOfCELO }) => (
         The logo was inert on every page, so /keys, /signin and /auth-error
         had no way back to the faucet at all.
       */}
+      {/*
+        Uses the network it was handed rather than a constant: pages that are
+        not network-scoped pass celo-sepolia explicitly, and a second chain
+        would otherwise send its own logo to the wrong faucet.
+      */}
       <Link
-        href={HOME_HREF}
+        href={`/${network}`}
         aria-label="Celo faucet home"
         className={`${styles.logo} dark:filter-[invert(1)]`}
       >

--- a/apps/web/components/faucet-header.tsx
+++ b/apps/web/components/faucet-header.tsx
@@ -1,14 +1,19 @@
+import Link from 'next/link'
 import { FC } from 'react'
 import { GitHubAuth } from 'components/github-auth'
 import { Logo } from 'components/logo'
 import { ModeToggle } from 'components/mode-toggle'
 import styles from 'styles/FaucetHeader.module.css'
 import { Network } from 'types'
+import { inter } from 'utils/inter'
 
 interface Props {
   network: Network
   isOutOfCELO: boolean
 }
+
+/** The faucet itself. Every page can get back here. */
+export const HOME_HREF = '/celo-sepolia'
 
 export const FaucetHeader: FC<Props> = ({ network, isOutOfCELO }) => (
   <div className={styles.top}>
@@ -18,10 +23,24 @@ export const FaucetHeader: FC<Props> = ({ network, isOutOfCELO }) => (
       </header>
     )}
     <div className={`${styles.topBar}`}>
-      <div className={`${styles.logo} dark:filter-[invert(1)]`}>
+      {/*
+        The logo was inert on every page, so /keys, /signin and /auth-error
+        had no way back to the faucet at all.
+      */}
+      <Link
+        href={HOME_HREF}
+        aria-label="Celo faucet home"
+        className={`${styles.logo} dark:filter-[invert(1)]`}
+      >
         <Logo />
-      </div>
-      <div className="flex flex-row items-end gap-3 pr-[40px]">
+      </Link>
+      <div className="flex flex-row items-center gap-3 pr-[40px]">
+        <Link
+          href="/keys"
+          className={`${inter.className} text-sm underline underline-offset-4`}
+        >
+          For Agents
+        </Link>
         <GitHubAuth />
         <ModeToggle />
       </div>

--- a/apps/web/styles/FaucetHeader.module.css
+++ b/apps/web/styles/FaucetHeader.module.css
@@ -9,6 +9,7 @@
 }
 
 .logo {
+  display: inline-block;
   margin-top: 20px;
   margin-left: 20px;
 }

--- a/apps/web/tests/faucet-header.test.ts
+++ b/apps/web/tests/faucet-header.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * No jsdom/RTL in this repo, so this asserts the source rather than a render.
+ * Thin, but it pins the two things that were missing: the logo was inert on
+ * every page, and there was no route between the faucet and /keys.
+ */
+const source = readFileSync(
+  join(__dirname, '..', 'components', 'faucet-header.tsx'),
+  'utf8',
+)
+
+describe('FaucetHeader navigation', () => {
+  // Regression: /keys, /signin and /auth-error had no way back to the faucet.
+  it('wraps the logo in a link home', () => {
+    expect(source).toMatch(/<Link[\s\S]*?href=\{HOME_HREF\}[\s\S]*?<Logo \/>/)
+  })
+
+  it('gives the logo link an accessible name', () => {
+    expect(source).toMatch(/aria-label="Celo faucet home"/)
+  })
+
+  it('points home at the faucet itself', () => {
+    expect(source).toMatch(/HOME_HREF = '\/celo-sepolia'/)
+  })
+
+  it('offers a single nav item to the agent page', () => {
+    expect(source).toContain('For Agents')
+    expect(source).toMatch(/href="\/keys"/)
+  })
+
+  it('keeps the logo out of the right-hand controls', () => {
+    // The logo must stay on the left of the flex row, not beside the toggles.
+    const rightHandSide = source.slice(source.indexOf('flex flex-row'))
+    expect(rightHandSide).not.toContain('<Logo />')
+  })
+})

--- a/apps/web/tests/faucet-header.test.ts
+++ b/apps/web/tests/faucet-header.test.ts
@@ -15,15 +15,21 @@ const source = readFileSync(
 describe('FaucetHeader navigation', () => {
   // Regression: /keys, /signin and /auth-error had no way back to the faucet.
   it('wraps the logo in a link home', () => {
-    expect(source).toMatch(/<Link[\s\S]*?href=\{HOME_HREF\}[\s\S]*?<Logo \/>/)
+    expect(source).toMatch(
+      /<Link[\s\S]*?href=\{`\/\$\{network\}`\}[\s\S]*?<Logo \/>/,
+    )
   })
 
   it('gives the logo link an accessible name', () => {
     expect(source).toMatch(/aria-label="Celo faucet home"/)
   })
 
-  it('points home at the faucet itself', () => {
-    expect(source).toMatch(/HOME_HREF = '\/celo-sepolia'/)
+  // Regression: this was hardcoded to /celo-sepolia while the component was
+  // already being handed the network, so a second chain would have linked its
+  // own logo to the wrong faucet.
+  it('links home using the network it was given, not a constant', () => {
+    expect(source).toMatch(/href=\{`\/\$\{network\}`\}/)
+    expect(source).not.toMatch(/href="\/celo-sepolia"/)
   })
 
   it('offers a single nav item to the agent page', () => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['**/*.test.ts'],
+    include: ['**/*.test.ts', '**/*.test.tsx'],
     exclude: ['node_modules/**', '.next/**'],
   },
 })


### PR DESCRIPTION
### Description

There was no navigation between the faucet and the API-key page, and **the logo was inert on every page**. From `/keys`, `/signin` or `/auth-error` the only way back to the faucet was editing the URL.

- The logo is now a link to the faucet, with `aria-label="Celo faucet home"`.
- Adds a single nav item, **For Agents**, pointing at `/keys`, so the API-key page is reachable from the faucet itself rather than only from a footer bullet.

Both live in `FaucetHeader`, so every page that renders the header gets them.

### Other changes

Widens the vitest `include` to cover `.test.tsx`. The first version of this test was a `.tsx` file and **silently did not run** — worth closing before anyone adds a real component test and believes a passing suite.

`.logo` gains `display: inline-block`, since the class sets margins that a bare inline `<a>` would not honour.

### Tested

```
web vitest   94 passed (94)   (89 before, +5)
tsc          exit 0
lint         clean
build        compiled
```

Verified in the rendered HTML on both pages rather than only in the source:

```
/celo-sepolia   logo-link=1   For-Agents=1
/keys           logo-link=1   For-Agents=1
```

Screenshotted `/keys` — "For Agents" sits inline with the GitHub button and theme toggle, and the logo is unchanged visually.

No jsdom or RTL in this repo, so the tests assert the component source. Thin, and stated as such in the file, but they pin the two things that were actually missing plus one layout invariant (the logo must not drift into the right-hand controls).

### Related issues

None. Requested directly.

### Backwards compatibility

Compatible. `FaucetHeader` keeps its existing props; the change is additive markup. The logo now navigates on click, where before it did nothing.

### Documentation

None needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
